### PR TITLE
Replace Core Data observer with SwiftData sync notifications

### DIFF
--- a/FinanceApp.xcodeproj/project.pbxproj
+++ b/FinanceApp.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		6C486BC8EF541BB0A6BD883F /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30291B0B5A4EE798BF018BCA /* Category.swift */; };
 		7301720ADC58D0A41019896E /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */; };
 		735D34967E74D4C3250D7953 /* SyncMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */; };
+		75A1F6A5FBDF33E336296B04 /* SyncNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F033E700F21E7EECE9D67EEC /* SyncNotification.swift */; };
+		775BC8AB86F17D0D3605D578 /* SyncNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F033E700F21E7EECE9D67EEC /* SyncNotification.swift */; };
 		79BC6BCA209688107CD14316 /* AccountFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAE2122E580270E6589F42A /* AccountFormView.swift */; };
 		7A8AD50E4E9326E7DE22FC63 /* SyncMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */; };
 		84A23B41A1064577235D0167 /* FinanceEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAA3B252A56C9684A046F01 /* FinanceEnums.swift */; };
@@ -131,7 +133,7 @@
 		96B4DCFA088617AB728946AE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingByCategoryView.swift; sourceTree = "<group>"; };
 		9A85E740A87AB032DE8F2903 /* AccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewModel.swift; sourceTree = "<group>"; };
-		9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FinanceApp-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "FinanceApp-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D21D56850CF85FAB1133DF2 /* CurrencyExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExtensions.swift; sourceTree = "<group>"; };
 		A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
 		A77AF046245108EC8F0FCB5E /* AccountDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailView.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 		DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		E1A4D54B054822B31C2F04F3 /* TransactionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRowView.swift; sourceTree = "<group>"; };
 		EAF762C3621015C0856200B4 /* TransferFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferFormView.swift; sourceTree = "<group>"; };
+		F033E700F21E7EECE9D67EEC /* SyncNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncNotification.swift; sourceTree = "<group>"; };
 		F9080BF6AEE035BDBF614C5B /* FinanceApp-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FinanceApp-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -248,6 +251,7 @@
 				351D8BF8152B5DBFBD50BB20 /* SupabaseManager.swift */,
 				A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */,
 				7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */,
+				F033E700F21E7EECE9D67EEC /* SyncNotification.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -440,6 +444,12 @@
 					179D7A42FC947BCA1864ABE5 = {
 						DevelopmentTeam = "";
 					};
+					93228A74122FF530C5862FB4 = {
+						DevelopmentTeam = "";
+					};
+					AA44AD860E97EC2AD74ED23D = {
+						DevelopmentTeam = "";
+					};
 					E110A3AEDF6E1E2D3FA75FE6 = {
 						DevelopmentTeam = "";
 					};
@@ -530,6 +540,7 @@
 				DE8402B7FD542CAF6646E107 /* SupabaseManager.swift in Sources */,
 				21C25963DD2D0F1F621B773F /* SyncEngine.swift in Sources */,
 				735D34967E74D4C3250D7953 /* SyncMetadata.swift in Sources */,
+				775BC8AB86F17D0D3605D578 /* SyncNotification.swift in Sources */,
 				7301720ADC58D0A41019896E /* Transaction.swift in Sources */,
 				D8E255602F522F4D52097FF0 /* TransactionFormView.swift in Sources */,
 				915BB4586AA9C91A8069C93E /* TransactionListView.swift in Sources */,
@@ -572,6 +583,7 @@
 				0479D3DA656AB2ACB0D022FD /* SupabaseManager.swift in Sources */,
 				3BFA175B8C2AA04F6325E4CC /* SyncEngine.swift in Sources */,
 				7A8AD50E4E9326E7DE22FC63 /* SyncMetadata.swift in Sources */,
+				75A1F6A5FBDF33E336296B04 /* SyncNotification.swift in Sources */,
 				999B4922AB6BE9AF8D3CF0F9 /* Transaction.swift in Sources */,
 				EEFAE6176EAA59BFE1844C09 /* TransactionFormView.swift in Sources */,
 				632DD410BDBB1D8FAFAA6CE9 /* TransactionListView.swift in Sources */,
@@ -614,7 +626,6 @@
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -623,7 +634,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -720,7 +731,6 @@
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -729,7 +739,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -777,11 +787,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -790,8 +797,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -804,11 +810,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -817,8 +820,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Sources/Services/Sync/SyncEngine.swift
+++ b/Sources/Services/Sync/SyncEngine.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SwiftData
-import CoreData
 import Supabase
 import Observation
 
@@ -79,28 +78,20 @@ final class SyncEngine {
 
     private func observeLocalSaves() {
         saveObserver = NotificationCenter.default.addObserver(
-            forName: .NSManagedObjectContextDidSave,
+            forName: SyncNotification.didSaveLocalData,
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            // Extract data on the calling thread before crossing isolation
-            let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>
-            let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>
-            let deletedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject>
-
-            let inserted = Self.extractEntityIds(from: insertedObjects, changeType: .insert)
-            let updated = Self.extractEntityIds(from: updatedObjects, changeType: .update)
-            let deleted = Self.extractEntityIds(from: deletedObjects, changeType: .delete)
-
-            let allChanges = inserted + updated + deleted
+            let changes = notification.userInfo?[SyncNotification.changesKey]
+                as? [SyncNotification.Change] ?? []
 
             Task { @MainActor in
-                self?.handleExtractedChanges(allChanges)
+                self?.handleNotifiedChanges(changes)
             }
         }
     }
 
-    private func handleExtractedChanges(_ changes: [TrackedChange]) {
+    private func handleNotifiedChanges(_ changes: [SyncNotification.Change]) {
         guard !isPulling else { return }
         guard !changes.isEmpty else { return }
 
@@ -117,41 +108,6 @@ final class SyncEngine {
 
         try? context.save()
         schedulePush()
-    }
-
-    private struct TrackedChange: Sendable {
-        let entityType: SyncMetadata.EntityType
-        let entityId: UUID
-        let changeType: SyncMetadata.ChangeType
-    }
-
-    nonisolated private static func extractEntityIds(
-        from objects: Set<NSManagedObject>?,
-        changeType: SyncMetadata.ChangeType
-    ) -> [TrackedChange] {
-        guard let managedObjects = objects else {
-            return []
-        }
-
-        return managedObjects.compactMap { (object: NSManagedObject) -> TrackedChange? in
-            let entityName = object.entity.name ?? ""
-
-            let entityType: SyncMetadata.EntityType
-            switch entityName {
-            case "Account": entityType = .account
-            case "Transaction": entityType = .transaction
-            case "Category": entityType = .category
-            default: return nil
-            }
-
-            guard let id = object.value(forKey: "id") as? UUID else { return nil }
-
-            return TrackedChange(
-                entityType: entityType,
-                entityId: id,
-                changeType: changeType
-            )
-        }
     }
 
     // MARK: - Push (Local → Remote)

--- a/Sources/Services/Sync/SyncNotification.swift
+++ b/Sources/Services/Sync/SyncNotification.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+// MARK: - Sync Change Notification
+
+/// Lightweight notification system for SwiftData saves.
+///
+/// SwiftData's `ModelContext.save()` does NOT post
+/// `NSManagedObjectContextDidSave` (that's Core Data only).
+/// ViewModels post `.didSaveLocalData` after each save so
+/// SyncEngine can queue the change for push.
+enum SyncNotification {
+
+    /// Posted by ViewModels after a successful `modelContext.save()`.
+    static let didSaveLocalData = Notification.Name("SyncDidSaveLocalData")
+
+    // MARK: - UserInfo Keys
+
+    static let changesKey = "syncChanges"
+
+    // MARK: - Change Descriptor
+
+    /// Describes a single entity change to be synced.
+    struct Change: Sendable {
+        let entityType: SyncMetadata.EntityType
+        let entityId: UUID
+        let changeType: SyncMetadata.ChangeType
+    }
+
+    // MARK: - Post Helpers
+
+    /// Post a single entity change.
+    static func post(
+        entityType: SyncMetadata.EntityType,
+        entityId: UUID,
+        changeType: SyncMetadata.ChangeType
+    ) {
+        let change = Change(
+            entityType: entityType,
+            entityId: entityId,
+            changeType: changeType
+        )
+        NotificationCenter.default.post(
+            name: didSaveLocalData,
+            object: nil,
+            userInfo: [changesKey: [change]]
+        )
+    }
+
+    /// Post multiple entity changes at once (e.g., transfer pairs).
+    static func post(changes: [Change]) {
+        guard !changes.isEmpty else { return }
+        NotificationCenter.default.post(
+            name: didSaveLocalData,
+            object: nil,
+            userInfo: [changesKey: changes]
+        )
+    }
+}

--- a/Sources/ViewModels/AccountViewModel.swift
+++ b/Sources/ViewModels/AccountViewModel.swift
@@ -24,6 +24,7 @@ final class AccountViewModel {
         )
         modelContext.insert(account)
         try modelContext.save()
+        SyncNotification.post(entityType: .account, entityId: account.id, changeType: .insert)
     }
 
     func updateAccount(
@@ -38,11 +39,14 @@ final class AccountViewModel {
         account.currency = currency.rawValue
         account.icon = icon
         try modelContext.save()
+        SyncNotification.post(entityType: .account, entityId: account.id, changeType: .update)
     }
 
     func deleteAccount(_ account: Account) throws {
+        let accountId = account.id
         modelContext.delete(account)
         try modelContext.save()
+        SyncNotification.post(entityType: .account, entityId: accountId, changeType: .delete)
     }
 
     func formattedBalance(for account: Account) -> String {

--- a/Sources/ViewModels/TransactionViewModel.swift
+++ b/Sources/ViewModels/TransactionViewModel.swift
@@ -28,6 +28,7 @@ final class TransactionViewModel {
         )
         modelContext.insert(transaction)
         try modelContext.save()
+        SyncNotification.post(entityType: .transaction, entityId: transaction.id, changeType: .insert)
     }
 
     func updateTransaction(
@@ -46,14 +47,17 @@ final class TransactionViewModel {
         transaction.account = account
         transaction.category = category
         try modelContext.save()
+        SyncNotification.post(entityType: .transaction, entityId: transaction.id, changeType: .update)
     }
 
     func deleteTransaction(_ transaction: Transaction) throws {
         if let transferId = transaction.transferId {
             try deleteTransferPair(transferId: transferId)
         } else {
+            let transactionId = transaction.id
             modelContext.delete(transaction)
             try modelContext.save()
+            SyncNotification.post(entityType: .transaction, entityId: transactionId, changeType: .delete)
         }
     }
 
@@ -62,9 +66,14 @@ final class TransactionViewModel {
             predicate: #Predicate<Transaction> { $0.transferId == transferId }
         )
         let paired = try modelContext.fetch(descriptor)
+        let pairedIds = paired.map(\.id)
         for transaction in paired {
             modelContext.delete(transaction)
         }
         try modelContext.save()
+        let changes = pairedIds.map { id in
+            SyncNotification.Change(entityType: .transaction, entityId: id, changeType: .delete)
+        }
+        SyncNotification.post(changes: changes)
     }
 }

--- a/Sources/ViewModels/TransferViewModel.swift
+++ b/Sources/ViewModels/TransferViewModel.swift
@@ -48,6 +48,11 @@ final class TransferViewModel {
         modelContext.insert(debit)
         modelContext.insert(credit)
         try modelContext.save()
+
+        SyncNotification.post(changes: [
+            .init(entityType: .transaction, entityId: debit.id, changeType: .insert),
+            .init(entityType: .transaction, entityId: credit.id, changeType: .insert),
+        ])
     }
 
     private func findOrCreateTransferCategory(type: TransactionType) throws -> Category {

--- a/Sources/Views/Categories/CategoryFormView.swift
+++ b/Sources/Views/Categories/CategoryFormView.swift
@@ -177,6 +177,8 @@ struct CategoryFormView: View {
                 category.icon = icon
                 category.colorHex = colorHex
                 category.transactionType = transactionType.rawValue
+                try modelContext.save()
+                SyncNotification.post(entityType: .category, entityId: category.id, changeType: .update)
             } else {
                 let newCategory = Category(
                     name: trimmedName,
@@ -185,8 +187,9 @@ struct CategoryFormView: View {
                     transactionType: transactionType
                 )
                 modelContext.insert(newCategory)
+                try modelContext.save()
+                SyncNotification.post(entityType: .category, entityId: newCategory.id, changeType: .insert)
             }
-            try modelContext.save()
             dismiss()
         } catch {
             errorMessage = "Failed to save category: \(error.localizedDescription)"


### PR DESCRIPTION
## Changes

- **New `SyncNotification` system**: Created a lightweight notification-based sync change tracking system that works with SwiftData (replaces Core Data's `NSManagedObjectContextDidSave`)
  - Defines `SyncNotification.Change` struct to describe entity changes
  - Provides helper methods to post single and batch changes
  - Includes documentation on why this approach is needed for SwiftData

- **Simplified `SyncEngine`**: Removed Core Data-specific extraction logic
  - Replaced `NSManagedObjectContextDidSave` observer with `SyncNotification.didSaveLocalData`
  - Removed `TrackedChange` struct and `extractEntityIds` method
  - Renamed `handleExtractedChanges` to `handleNotifiedChanges`

- **Updated ViewModels**: Added explicit sync notifications after each save
  - `AccountViewModel`: Posts notifications for insert/update/delete
  - `TransactionViewModel`: Posts notifications including for transfer pair deletions
  - `TransferViewModel`: Posts batch notifications for transfer transaction pairs
  - `CategoryFormView`: Posts notifications for insert/update

- **Project cleanup**: Updated bundle identifiers and build configurations