### PR TITLE
Prevent duplicate default categories across devices

### DIFF
--- a/Sources/FinanceApp.swift
+++ b/Sources/FinanceApp.swift
@@ -37,6 +37,7 @@ struct FinanceApp: App {
             RootView(
                 authManager: authManager,
                 networkMonitor: networkMonitor,
+                syncEngine: syncEngine,
                 onAuthenticated: { startSync() },
                 onSeedCategories: {
                     DefaultCategorySeeder.seedIfNeeded(
@@ -68,7 +69,7 @@ struct FinanceApp: App {
         // Reset sync/migration flags so next sign-in starts fresh
         UserDefaults.standard.removeObject(forKey: AppConstants.lastSyncTimestampKey)
         UserDefaults.standard.removeObject(forKey: AppConstants.migrationCompletedKey)
-        UserDefaults.standard.removeObject(forKey: AppConstants.categorySeededKey)
+
 
         await authManager.signOut()
     }
@@ -97,6 +98,7 @@ struct FinanceApp: App {
 private struct RootView: View {
     let authManager: AuthManager
     let networkMonitor: NetworkMonitor
+    var syncEngine: SyncEngine?
     let onAuthenticated: () -> Void
     let onSeedCategories: () -> Void
 
@@ -107,8 +109,12 @@ private struct RootView: View {
             } else if authManager.isAuthenticated {
                 ContentView()
                     .onAppear {
-                        onSeedCategories()
                         onAuthenticated()
+                    }
+                    .onChange(of: syncEngine?.initialPullCompleted) { _, completed in
+                        if completed == true {
+                            onSeedCategories()
+                        }
                     }
             } else {
                 SignInView(authManager: authManager)

--- a/Sources/Services/DefaultCategorySeeder.swift
+++ b/Sources/Services/DefaultCategorySeeder.swift
@@ -5,8 +5,12 @@ struct DefaultCategorySeeder {
     private init() {}
 
     static func seedIfNeeded(modelContext: ModelContext) {
-        let hasSeeded = UserDefaults.standard.bool(forKey: AppConstants.categorySeededKey)
-        guard !hasSeeded else { return }
+        // Check the database for existing categories instead of a device-local flag.
+        // This prevents duplicate seeding across devices — if categories were already
+        // pulled from Supabase sync, we skip seeding entirely.
+        let descriptor = FetchDescriptor<Category>()
+        let existingCount = (try? modelContext.fetchCount(descriptor)) ?? 0
+        guard existingCount == 0 else { return }
 
         let expenseCategories: [(String, String, String)] = [
             ("Food & Dining", "fork.knife", "#FF6B6B"),
@@ -60,7 +64,6 @@ struct DefaultCategorySeeder {
 
         do {
             try modelContext.save()
-            UserDefaults.standard.set(true, forKey: AppConstants.categorySeededKey)
         } catch {
             print("Failed to seed default categories: \(error)")
         }

--- a/Sources/Services/Sync/SyncEngine.swift
+++ b/Sources/Services/Sync/SyncEngine.swift
@@ -26,6 +26,7 @@ final class SyncEngine {
     private(set) var isSyncing: Bool = false
     private(set) var lastSyncDate: Date?
     private(set) var syncError: String?
+    private(set) var initialPullCompleted: Bool = false
 
     private var realtimeChannel: RealtimeChannelV2?
     private var pushDebounceTask: Task<Void, Never>?
@@ -267,6 +268,7 @@ final class SyncEngine {
         guard authManager.isAuthenticated,
               let userId = authManager.userId,
               networkMonitor.isConnected else {
+            initialPullCompleted = true
             return
         }
 
@@ -311,10 +313,12 @@ final class SyncEngine {
             lastSyncDate = Date.now
             isSyncing = false
             isPulling = false
+            initialPullCompleted = true
 
         } catch {
             isSyncing = false
             isPulling = false
+            initialPullCompleted = true
             syncError = "Pull failed: \(error.localizedDescription)"
         }
     }

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -4,7 +4,6 @@ enum AppConstants {
     static let appName = "FinanceApp"
     static let defaultCurrencyCode = "USD"
     static let recentTransactionsLimit = 10
-    static let categorySeededKey = "hasSeededDefaultCategories"
     static let migrationCompletedKey = "supabaseMigrationCompleted"
     static let lastSyncTimestampKey = "lastSyncTimestamp"
 


### PR DESCRIPTION
## Changes

- **DefaultCategorySeeder**: Replace device-local flag with database check to prevent duplicate seeding across devices
  - Check if categories exist in the database instead of using UserDefaults
  - Ensures categories synced from Supabase aren't re-seeded locally

- **SyncEngine**: Add `initialPullCompleted` flag to track when initial sync is finished
  - Set flag to `true` after successful pull, on error, or when sync is unavailable
  - Enables proper coordination with category seeding

- **FinanceApp**: Update seeding logic to depend on sync completion
  - Pass `syncEngine` to RootView
  - Seed categories only after `initialPullCompleted` becomes true
  - Remove unnecessary UserDefaults cleanup on sign out

- **Constants**: Remove obsolete `categorySeededKey` constant