### PR TITLE
Fix: sync categories and transactions to Supabase

### DIFF
--- a/Sources/Services/DefaultCategorySeeder.swift
+++ b/Sources/Services/DefaultCategorySeeder.swift
@@ -40,6 +40,8 @@ struct DefaultCategorySeeder {
             ("Other", "ellipsis.circle", "#9E9E9E"),
         ]
 
+        var insertedCategories: [Category] = []
+
         for (name, icon, color) in expenseCategories {
             let category = Category(
                 name: name,
@@ -49,6 +51,7 @@ struct DefaultCategorySeeder {
                 isDefault: true
             )
             modelContext.insert(category)
+            insertedCategories.append(category)
         }
 
         for (name, icon, color) in incomeCategories {
@@ -60,10 +63,19 @@ struct DefaultCategorySeeder {
                 isDefault: true
             )
             modelContext.insert(category)
+            insertedCategories.append(category)
         }
 
         do {
             try modelContext.save()
+            let changes = insertedCategories.map { category in
+                SyncNotification.Change(
+                    entityType: .category,
+                    entityId: category.id,
+                    changeType: .insert
+                )
+            }
+            SyncNotification.post(changes: changes)
         } catch {
             print("Failed to seed default categories: \(error)")
         }

--- a/Sources/Services/Sync/SyncEngine.swift
+++ b/Sources/Services/Sync/SyncEngine.swift
@@ -139,10 +139,16 @@ final class SyncEngine {
             let pendingChanges = try context.fetch(descriptor)
             guard !pendingChanges.isEmpty else { return }
 
+            // Sort by entity type to satisfy FK dependencies:
+            // accounts first, then categories, then transactions.
+            let sortedChanges = pendingChanges.sorted {
+                $0.entityTypeEnum.pushOrder < $1.entityTypeEnum.pushOrder
+            }
+
             isSyncing = true
             syncError = nil
 
-            for metadata in pendingChanges {
+            for metadata in sortedChanges {
                 do {
                     try await pushSingleChange(metadata, userId: userId, context: context)
                     metadata.isSynced = true

--- a/Sources/Services/Sync/SyncMetadata.swift
+++ b/Sources/Services/Sync/SyncMetadata.swift
@@ -31,6 +31,16 @@ final class SyncMetadata {
         case account
         case transaction
         case category
+
+        /// Push ordering to satisfy foreign key dependencies.
+        /// Accounts and categories must be pushed before transactions.
+        var pushOrder: Int {
+            switch self {
+            case .account: 0
+            case .category: 1
+            case .transaction: 2
+            }
+        }
     }
 
     // MARK: - Computed

--- a/Sources/ViewModels/TransferViewModel.swift
+++ b/Sources/ViewModels/TransferViewModel.swift
@@ -18,8 +18,13 @@ final class TransferViewModel {
     ) throws {
         let transferId = UUID().uuidString
 
-        let transferCategory = try findOrCreateTransferCategory(type: .expense)
-        let transferIncomeCategory = try findOrCreateTransferCategory(type: .income)
+        var newCategoryChanges: [SyncNotification.Change] = []
+        let transferCategory = try findOrCreateTransferCategory(
+            type: .expense, newChanges: &newCategoryChanges
+        )
+        let transferIncomeCategory = try findOrCreateTransferCategory(
+            type: .income, newChanges: &newCategoryChanges
+        )
 
         let defaultNotes = notes.isEmpty
             ? "Transfer from \(sourceAccount.name) to \(destinationAccount.name)"
@@ -49,13 +54,16 @@ final class TransferViewModel {
         modelContext.insert(credit)
         try modelContext.save()
 
-        SyncNotification.post(changes: [
+        SyncNotification.post(changes: newCategoryChanges + [
             .init(entityType: .transaction, entityId: debit.id, changeType: .insert),
             .init(entityType: .transaction, entityId: credit.id, changeType: .insert),
         ])
     }
 
-    private func findOrCreateTransferCategory(type: TransactionType) throws -> Category {
+    private func findOrCreateTransferCategory(
+        type: TransactionType,
+        newChanges: inout [SyncNotification.Change]
+    ) throws -> Category {
         let typeRaw = type.rawValue
         let descriptor = FetchDescriptor<Category>(
             predicate: #Predicate<Category> {
@@ -74,6 +82,7 @@ final class TransferViewModel {
             isDefault: true
         )
         modelContext.insert(category)
+        newChanges.append(.init(entityType: .category, entityId: category.id, changeType: .insert))
         return category
     }
 }


### PR DESCRIPTION
## Changes

- **DefaultCategorySeeder**: Track inserted categories and post sync notifications when seeding completes
- **SyncEngine**: Sort pending changes by entity type to satisfy foreign key dependencies (accounts → categories → transactions)
- **SyncMetadata**: Add `pushOrder` property to EntityType enum for ordering sync operations
- **TransferViewModel**: Capture category creation changes and include them in sync notifications when creating transfers

## Key Improvements

- Ensures categories are synced before transactions that reference them
- Properly tracks all category changes for Supabase synchronization
- Maintains referential integrity during sync operations