### PR TITLE
Add iOS sign-out option and fix SignInView sizing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,13 @@
 # FinanceApp
 
-Personal finance app for macOS 14+ and iOS 17+. Manages multiple accounts, transfers, income/expense tracking with categories, and syncs via iCloud/CloudKit.
+Personal finance app for macOS 14+ and iOS 17+. Manages multiple accounts, transfers, income/expense tracking with categories. Syncs across devices via Supabase (PostgreSQL + Realtime + Apple Sign-In).
 
 ## Tech Stack
 
-- **Swift 6.0** / **SwiftUI** / **SwiftData** (persistence) / **CloudKit** (iCloud sync)
+- **Swift 6.0** / **SwiftUI** / **SwiftData** (local persistence) / **Supabase** (remote sync + auth)
 - **XcodeGen** (`project.yml` generates `FinanceApp.xcodeproj`)
 - **Architecture**: MVVM — Views own `@State`, ViewModels hold business logic, Models are `@Model` classes
+- **Supabase Swift SDK** v2 (SPM dependency)
 
 ## Build & Test
 
@@ -27,23 +28,29 @@ xcodebuild test -scheme FinanceApp-macOS -configuration Debug CODE_SIGNING_ALLOW
 xcodebuild test -scheme FinanceApp-iOS -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
 ```
 
-After modifying `project.yml`, regenerate the Xcode project: `xcodegen generate`
+After modifying `project.yml`, regenerate the Xcode project: `/opt/homebrew/bin/xcodegen generate`
 
 ## Project Structure
 
 ```
 Sources/
-├── FinanceApp.swift              # @main, ModelContainer + CloudKit config
+├── FinanceApp.swift              # @main, ModelContainer + SyncEngine + AuthManager setup
 ├── Models/                       # @Model classes (Account, Transaction, Category, FinanceEnums)
+│   └── (SyncMetadata)            # @Model for sync outbox tracking
 ├── ViewModels/                   # @Observable business logic (Account, Transaction, Transfer, Dashboard)
 ├── Views/
 │   ├── ContentView.swift         # Root nav: NavigationSplitView (iPad/macOS) vs TabView (iPhone)
+│   ├── Auth/                     # SignInView (Apple Sign-In)
 │   ├── Dashboard/                # DashboardView, SankeyDiagramView, SpendingByCategoryView
 │   ├── Accounts/                 # AccountList, AccountDetail, AccountForm
 │   ├── Transactions/             # TransactionList, TransactionForm, TransactionRow
 │   ├── Categories/               # CategoryList, CategoryForm
 │   └── Transfers/                # TransferForm
-├── Services/                     # CurrencyFormatter, DefaultCategorySeeder
+├── Services/
+│   ├── Auth/                     # AuthManager (Supabase Auth + Apple Sign-In)
+│   ├── Sync/                     # SyncEngine, SupabaseManager, EntityMapper, NetworkMonitor, SyncMetadata
+│   ├── CurrencyFormatter.swift
+│   └── DefaultCategorySeeder.swift
 ├── Utilities/                    # Constants, CurrencyExtensions, DateExtensions
 └── Resources/                    # Assets.xcassets
 Tests/
@@ -65,11 +72,42 @@ Transfers create two linked `Transaction` objects sharing a `transferId` (UUID s
 ### Balance is computed, never stored
 `Account.balanceInCents` sums all related transactions (income positive, expense negative).
 
-### CloudKit constraints
-All `@Model` properties have defaults, all relationships are optional, enums stored as `String` raw values, no `#Unique` constraints. Sync mode is `.automatic` (reads container ID from entitlements).
-
 ### Multi-platform layout
 `ContentView` checks `horizontalSizeClass`: compact → iPhone `TabView`; regular → iPad/macOS `NavigationSplitView` with sidebar. Platform-specific code uses `#if os(iOS)` / `#if os(macOS)`.
+
+## Sync Architecture
+
+```
+Views (@Query) → SwiftData (local) ←→ SyncEngine ←→ Supabase (remote)
+                                          ↑
+                                   SupabaseManager + AuthManager
+```
+
+- **SwiftData** is the single source of truth for the UI
+- **SyncEngine** pushes local changes to Supabase and pulls remote changes into SwiftData
+- **Outbox pattern**: `NSManagedObjectContextDidSave` notifications queue changes in `SyncMetadata` model
+- **Push**: Debounced 2s after local saves; immediate on connectivity restored
+- **Pull**: Full pull on login + Supabase Realtime subscription for live updates
+- **Conflict resolution**: Last-write-wins based on `updated_at`
+- **Offline-first**: Changes queue locally in `SyncMetadata` while offline, flush when online
+- **Migration**: On first Supabase sign-in, all existing local data is bulk-uploaded
+
+### Key Files
+- `SupabaseManager.swift` — Singleton `SupabaseClient` initialized from `AppConstants`
+- `AuthManager.swift` — Apple Sign-In → Supabase token, session restore, sign out
+- `SyncEngine.swift` — Push/pull orchestration, realtime subscription, migration
+- `SyncMetadata.swift` — `@Model` tracking pending changes (entityType, entityId, changeType)
+- `EntityMapper.swift` — Bidirectional mapping: SwiftData models ↔ `Supabase*Row` Codable DTOs
+- `NetworkMonitor.swift` — `NWPathMonitor` wrapper, posts `.connectivityRestored` notification
+
+### Supabase DTOs
+Row types use `Supabase` prefix to avoid name collisions with the Supabase SDK:
+- `SupabaseAccountRow`, `SupabaseTransactionRow`, `SupabaseCategoryRow`, `SoftDeleteRow`
+
+### Supabase Config
+- URL: configured in `AppConstants.supabaseURL`
+- Anon Key: configured in `AppConstants.supabaseAnonKey`
+- Auth: Apple Sign-In (entitlement: `com.apple.developer.applesignin`)
 
 ## Code Conventions
 
@@ -83,15 +121,15 @@ All `@Model` properties have defaults, all relationships are optional, enums sto
 - **Validation**: `isFormValid` computed property gates the save button with `.disabled(!isFormValid)`
 - **No mutation of existing objects outside ViewModels** — all CRUD through ViewModel methods
 - **Immutable patterns preferred** — create new values rather than mutating in-place where possible
+- **Swift 6 concurrency**: `@MainActor` on observable classes, `Sendable` structs for DTOs
 
 ## Adding a New File to the Project
 
 When creating a new Swift file:
 
 1. Place it in the appropriate `Sources/` subdirectory
-2. Add to `project.yml` under both iOS and macOS target sources (or regenerate)
-3. **OR** manually add to `project.pbxproj`: PBXFileReference + PBXGroup + PBXBuildFile (×2, one per target) + PBXSourcesBuildPhase (×2)
-4. Build both targets to verify
+2. Run `/opt/homebrew/bin/xcodegen generate` to regenerate the project
+3. Build both targets to verify
 
 ## Data Models
 
@@ -100,15 +138,17 @@ When creating a new Swift file:
 | **Account** | name, accountType (String), currency (String), icon (String), createdDate | → [Transaction] (cascade) |
 | **Transaction** | amountInCents (Int64), transactionType (String), date, notes, transferId? | → Account?, Category? |
 | **Category** | name, icon, colorHex, transactionType (String), isDefault (Bool) | → [Transaction] (nullify) |
+| **SyncMetadata** | entityType (String), entityId (String), changeType (String), isSynced, retryCount | — |
 
 ## Supported Currencies
 
 USD, EUR, GBP, JPY, CAD, AUD, CHF, CNY, INR, MXN, BRL, KRW, SEK, NOK, DKK — defined in `SupportedCurrency` enum in `FinanceEnums.swift`.
 
-## iCloud Sync
+## PostgreSQL Schema (Supabase)
 
-- Container: `iCloud.com.eduardopenedos.FinanceApp`
-- Bundle ID: `com.eduardopenedos.FinanceApp`
-- Development Team: `MV45ATG98E`
-- Entitlements: CloudKit, ubiquity KVStore, `aps-environment: development`
-- Remote changes merged via `NSPersistentStoreRemoteChange` + `NSPersistentCloudKitContainer.eventChangedNotification`
+Three tables with Row-Level Security (RLS) — each row has `user_id` for isolation:
+- `accounts` — mirrors Account model + `updated_at`, `deleted_at` (soft delete)
+- `categories` — mirrors Category model + `updated_at`, `deleted_at`
+- `transactions` — mirrors Transaction model + `updated_at`, `deleted_at`, FK to accounts/categories
+
+SQL migration is in the plan file: `~/.claude/plans/sleepy-wondering-karp.md`

--- a/FinanceApp.entitlements
+++ b/FinanceApp.entitlements
@@ -2,17 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.icloud-container-identifiers</key>
+	<key>com.apple.developer.applesignin</key>
 	<array>
-		<string>iCloud.com.eduardopenedos.FinanceApp</string>
+		<string>Default</string>
 	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudKit</string>
-	</array>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-	<key>aps-environment</key>
-	<string>development</string>
 </dict>
 </plist>

--- a/FinanceApp.xcodeproj/project.pbxproj
+++ b/FinanceApp.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		EAC35CEC73059EF78C3F6D58 /* SpendingByCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */; };
 		EEFAE6176EAA59BFE1844C09 /* TransactionFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC982E2DB527B7B82DD9D2E2 /* TransactionFormView.swift */; };
 		F3A437B701D9D55A7BA0F398 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2BF3E84AB186AC4DC3E106 /* DashboardViewModel.swift */; };
+		F1A2B3C4D5E6F7A8B9C0D1E3 /* SettingsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E2 /* SettingsTabView.swift */; };
+		F1A2B3C4D5E6F7A8B9C0D1E4 /* SettingsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E2 /* SettingsTabView.swift */; };
 		F8E9C3A98E5D021752ABB425 /* AccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A85E740A87AB032DE8F2903 /* AccountViewModel.swift */; };
 		FC81346A832E671DA34E18C2 /* AccountDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AF046245108EC8F0FCB5E /* AccountDetailView.swift */; };
 /* End PBXBuildFile section */
@@ -126,6 +128,7 @@
 		6E0802AC8872D381C533EC2B /* EntityMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityMapper.swift; sourceTree = "<group>"; };
 		71036145556962D8CF8DA6BA /* DateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
 		73D0A46C7E82AA74BF0CF8EA /* SignOutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutAction.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E2 /* SettingsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTabView.swift; sourceTree = "<group>"; };
 		79660E617343DE13EF9FE68C /* TransferViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferViewModel.swift; sourceTree = "<group>"; };
 		7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMetadata.swift; sourceTree = "<group>"; };
 		8C096909BB72F234A3DAF492 /* SankeyDiagramView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SankeyDiagramView.swift; sourceTree = "<group>"; };
@@ -283,6 +286,14 @@
 			path = Auth;
 			sourceTree = "<group>";
 		};
+		F1A2B3C4D5E6F7A8B9C0D1E5 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				F1A2B3C4D5E6F7A8B9C0D1E2 /* SettingsTabView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		9A7208E1A1DDCC0885F31A48 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -291,6 +302,7 @@
 				F033D283B5CC559A03153B69 /* Auth */,
 				88B5C39A015F9FAD70906EBE /* Categories */,
 				EBA5EB0E77B6C97E696A6B4F /* Dashboard */,
+				F1A2B3C4D5E6F7A8B9C0D1E5 /* Settings */,
 				44BCB3E841FBA57AD7D78260 /* Transactions */,
 				0166FB86C6861D153D96B439 /* Transfers */,
 			);
@@ -528,6 +540,7 @@
 				6AEE97C763CD8491B6387807 /* FinanceEnums.swift in Sources */,
 				48197DC18D318B1036EE5333 /* NetworkMonitor.swift in Sources */,
 				A0A8AB6407550D3F3F0B8EC1 /* SankeyDiagramView.swift in Sources */,
+				F1A2B3C4D5E6F7A8B9C0D1E3 /* SettingsTabView.swift in Sources */,
 				5D152F031438789FDF4C2F47 /* SignInView.swift in Sources */,
 				959ECF429748EC7BA1D1BCBA /* SignOutAction.swift in Sources */,
 				EAC35CEC73059EF78C3F6D58 /* SpendingByCategoryView.swift in Sources */,
@@ -571,6 +584,7 @@
 				84A23B41A1064577235D0167 /* FinanceEnums.swift in Sources */,
 				E25EDF3BEA78C5D1F9BD5A73 /* NetworkMonitor.swift in Sources */,
 				275AA26820F8E384A1F83022 /* SankeyDiagramView.swift in Sources */,
+				F1A2B3C4D5E6F7A8B9C0D1E4 /* SettingsTabView.swift in Sources */,
 				AD9EF97D4FCEDCC35EED472B /* SignInView.swift in Sources */,
 				BE8D1F2D22534C750DC09DE1 /* SignOutAction.swift in Sources */,
 				137290AE8511E5A30C8D2C6A /* SpendingByCategoryView.swift in Sources */,

--- a/FinanceApp.xcodeproj/project.pbxproj
+++ b/FinanceApp.xcodeproj/project.pbxproj
@@ -7,33 +7,44 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0479D3DA656AB2ACB0D022FD /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351D8BF8152B5DBFBD50BB20 /* SupabaseManager.swift */; };
 		06351BC6B19380D5A9E34EB4 /* FinanceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221B74E5A3978E147141A824 /* FinanceApp.swift */; };
 		09D62437BD94E64B7044F8BE /* TransactionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E328665DDADB6D117410283 /* TransactionViewModel.swift */; };
 		0ED340BE636F82A7FE403E16 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26401E20BC231490FD3FDBAA /* DashboardView.swift */; };
+		0F8C724207FA8A011C97A700 /* EntityMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0802AC8872D381C533EC2B /* EntityMapper.swift */; };
 		0F904C40D1A7D381ED3CE634 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6F49BDD3FA0A7D05AA31B6 /* CurrencyFormatter.swift */; };
 		137290AE8511E5A30C8D2C6A /* SpendingByCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */; };
-		1A3B4C5D6E7F8A9B0C1D2E3F /* SankeyDiagramView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B3C4D5E6F7A8B9C0D1E2F /* SankeyDiagramView.swift */; };
 		1D7E2E200B4B9DFFDB70CA24 /* FinanceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221B74E5A3978E147141A824 /* FinanceApp.swift */; };
+		21C25963DD2D0F1F621B773F /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */; };
+		275AA26820F8E384A1F83022 /* SankeyDiagramView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C096909BB72F234A3DAF492 /* SankeyDiagramView.swift */; };
 		2C213950A8BB8B9B14285DF9 /* CategoryFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B66DD7159A431D4682F5CA /* CategoryFormView.swift */; };
 		352E734E7C9D3478D029E37D /* AccountListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6922A1E3A401FBC89C7CC373 /* AccountListView.swift */; };
 		3767CC5A3C0B9E303237DB2B /* TransactionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A4D54B054822B31C2F04F3 /* TransactionRowView.swift */; };
+		3A8343BCDB65E0D61BE50A2C /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ADE962AC5B8A7E3297014CA /* AuthManager.swift */; };
 		3B4130514C3242A00CB70763 /* TransferFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF762C3621015C0856200B4 /* TransferFormView.swift */; };
+		3BFA175B8C2AA04F6325E4CC /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */; };
 		420C0B43045C566350802946 /* DefaultCategorySeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2154A0C20ECFD1DE2A295CB6 /* DefaultCategorySeeder.swift */; };
+		48197DC18D318B1036EE5333 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0BE28E200C2BE7296C0630 /* NetworkMonitor.swift */; };
+		481AF0F8385697B65F55FE64 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = B0435966EF9A92504DAC2187 /* Supabase */; };
 		4C4EB3ADE44B8376536A30E5 /* AccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A85E740A87AB032DE8F2903 /* AccountViewModel.swift */; };
 		4CFC7E1C6EED1DD7CA006D05 /* AccountDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AF046245108EC8F0FCB5E /* AccountDetailView.swift */; };
+		5030F56739C02239CC5AB862 /* EntityMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0802AC8872D381C533EC2B /* EntityMapper.swift */; };
 		535C3A55AC56866D28D7FB81 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967E527AF6D0FB8425DA4ACE /* Constants.swift */; };
 		5453C8E693A881A97ECAF3B2 /* CurrencyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21D56850CF85FAB1133DF2 /* CurrencyExtensions.swift */; };
 		552F866F63F2732EE43032B6 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30291B0B5A4EE798BF018BCA /* Category.swift */; };
 		567F69D93BAF93B967D56748 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98C146C2855A66F996339BA /* Account.swift */; };
 		56DE1749DF9D5FE287647454 /* CurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD54CD5E49936C1BB7D7CB /* CurrencyTests.swift */; };
 		5972B156EE38C448D71D7373 /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9495D128EBDB2E48FC5D75 /* CategoryListView.swift */; };
+		5D152F031438789FDF4C2F47 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353B51A60B18513F9EE9BFE7 /* SignInView.swift */; };
 		6246A7E4DB498C227D13484A /* CurrencyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21D56850CF85FAB1133DF2 /* CurrencyExtensions.swift */; };
 		632DD410BDBB1D8FAFAA6CE9 /* TransactionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E1CB32A30167EA3D463FF7 /* TransactionListView.swift */; };
 		64C1D136583978B0A1081FE9 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98C146C2855A66F996339BA /* Account.swift */; };
 		6AEE97C763CD8491B6387807 /* FinanceEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAA3B252A56C9684A046F01 /* FinanceEnums.swift */; };
 		6C486BC8EF541BB0A6BD883F /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30291B0B5A4EE798BF018BCA /* Category.swift */; };
 		7301720ADC58D0A41019896E /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */; };
+		735D34967E74D4C3250D7953 /* SyncMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */; };
 		79BC6BCA209688107CD14316 /* AccountFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAE2122E580270E6589F42A /* AccountFormView.swift */; };
+		7A8AD50E4E9326E7DE22FC63 /* SyncMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */; };
 		84A23B41A1064577235D0167 /* FinanceEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAA3B252A56C9684A046F01 /* FinanceEnums.swift */; };
 		87E6D9293E871B44A1B9C30C /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9495D128EBDB2E48FC5D75 /* CategoryListView.swift */; };
 		915BB4586AA9C91A8069C93E /* TransactionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E1CB32A30167EA3D463FF7 /* TransactionListView.swift */; };
@@ -42,11 +53,14 @@
 		999B4922AB6BE9AF8D3CF0F9 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */; };
 		9B2DFB3FEC13E0CAF57ACDB2 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26401E20BC231490FD3FDBAA /* DashboardView.swift */; };
 		9ED468C796A72F74D81B43B6 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2BF3E84AB186AC4DC3E106 /* DashboardViewModel.swift */; };
+		A0A8AB6407550D3F3F0B8EC1 /* SankeyDiagramView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C096909BB72F234A3DAF492 /* SankeyDiagramView.swift */; };
 		A45D4A2A4B202EE6D2B862AC /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71036145556962D8CF8DA6BA /* DateExtensions.swift */; };
 		AAF64830DAEA23ED6F839FD0 /* CategoryFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B66DD7159A431D4682F5CA /* CategoryFormView.swift */; };
+		AD9EF97D4FCEDCC35EED472B /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353B51A60B18513F9EE9BFE7 /* SignInView.swift */; };
 		AEC1189CE0F5FFFC4F680B9F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 96B4DCFA088617AB728946AE /* Assets.xcassets */; };
 		B44D2C185E5E6797AE30F849 /* AccountFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAE2122E580270E6589F42A /* AccountFormView.swift */; };
 		B6B68B7738F84F0BAE3B2966 /* TransactionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A4D54B054822B31C2F04F3 /* TransactionRowView.swift */; };
+		BCD8D6C0BAD62B2F8B91ADFB /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 49CD362B2E504B37A7D21D72 /* Supabase */; };
 		C7D5962C41073C091B75392F /* TransactionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E328665DDADB6D117410283 /* TransactionViewModel.swift */; };
 		C835AF37AC16A905D2EB672F /* TransferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79660E617343DE13EF9FE68C /* TransferViewModel.swift */; };
 		CD9A07CD0DDCA580E2D71CC5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0DE65022CE25F226852F23 /* ContentView.swift */; };
@@ -56,11 +70,13 @@
 		D8E255602F522F4D52097FF0 /* TransactionFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC982E2DB527B7B82DD9D2E2 /* TransactionFormView.swift */; };
 		DE62B3C05D0FCDB9534EB50D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 96B4DCFA088617AB728946AE /* Assets.xcassets */; };
 		DE734BE37112C0D1967D1B0F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0DE65022CE25F226852F23 /* ContentView.swift */; };
+		DE8402B7FD542CAF6646E107 /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351D8BF8152B5DBFBD50BB20 /* SupabaseManager.swift */; };
+		DF365EF8BEB25464C2085587 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ADE962AC5B8A7E3297014CA /* AuthManager.swift */; };
 		E0530C04DC254B9750066D78 /* TransferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79660E617343DE13EF9FE68C /* TransferViewModel.swift */; };
+		E25EDF3BEA78C5D1F9BD5A73 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0BE28E200C2BE7296C0630 /* NetworkMonitor.swift */; };
 		E944B4E946C9300859C0E4FD /* DefaultCategorySeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2154A0C20ECFD1DE2A295CB6 /* DefaultCategorySeeder.swift */; };
 		EABC40144B1628BA20FA7C40 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71036145556962D8CF8DA6BA /* DateExtensions.swift */; };
 		EAC35CEC73059EF78C3F6D58 /* SpendingByCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */; };
-		EB1A2F3C4D5E6A7B8C9D0E1F /* SankeyDiagramView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B3C4D5E6F7A8B9C0D1E2F /* SankeyDiagramView.swift */; };
 		EEFAE6176EAA59BFE1844C09 /* TransactionFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC982E2DB527B7B82DD9D2E2 /* TransactionFormView.swift */; };
 		F3A437B701D9D55A7BA0F398 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2BF3E84AB186AC4DC3E106 /* DashboardViewModel.swift */; };
 		F8E9C3A98E5D021752ABB425 /* AccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A85E740A87AB032DE8F2903 /* AccountViewModel.swift */; };
@@ -87,6 +103,7 @@
 /* Begin PBXFileReference section */
 		0E6F49BDD3FA0A7D05AA31B6 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		0EAE2122E580270E6589F42A /* AccountFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountFormView.swift; sourceTree = "<group>"; };
+		1ADE962AC5B8A7E3297014CA /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		1B2BF3E84AB186AC4DC3E106 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		2154A0C20ECFD1DE2A295CB6 /* DefaultCategorySeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCategorySeeder.swift; sourceTree = "<group>"; };
 		221B74E5A3978E147141A824 /* FinanceApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceApp.swift; sourceTree = "<group>"; };
@@ -94,19 +111,26 @@
 		26401E20BC231490FD3FDBAA /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		30291B0B5A4EE798BF018BCA /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		33ADE858510CE519E569B24A /* FinanceAppTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FinanceAppTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		351D8BF8152B5DBFBD50BB20 /* SupabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
+		353B51A60B18513F9EE9BFE7 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		3E328665DDADB6D117410283 /* TransactionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewModel.swift; sourceTree = "<group>"; };
 		49E1CB32A30167EA3D463FF7 /* TransactionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListView.swift; sourceTree = "<group>"; };
 		4EAA3B252A56C9684A046F01 /* FinanceEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceEnums.swift; sourceTree = "<group>"; };
-		5A46FAEFF21370E7E1C9FABC /* FinanceAppTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FinanceAppTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5A46FAEFF21370E7E1C9FABC /* FinanceAppTests-iOS.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "FinanceAppTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6922A1E3A401FBC89C7CC373 /* AccountListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListView.swift; sourceTree = "<group>"; };
+		6D0BE28E200C2BE7296C0630 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		6E0802AC8872D381C533EC2B /* EntityMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityMapper.swift; sourceTree = "<group>"; };
 		71036145556962D8CF8DA6BA /* DateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
 		79660E617343DE13EF9FE68C /* TransferViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferViewModel.swift; sourceTree = "<group>"; };
+		7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMetadata.swift; sourceTree = "<group>"; };
+		8C096909BB72F234A3DAF492 /* SankeyDiagramView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SankeyDiagramView.swift; sourceTree = "<group>"; };
 		967E527AF6D0FB8425DA4ACE /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		96B4DCFA088617AB728946AE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingByCategoryView.swift; sourceTree = "<group>"; };
 		9A85E740A87AB032DE8F2903 /* AccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewModel.swift; sourceTree = "<group>"; };
 		9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FinanceApp-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D21D56850CF85FAB1133DF2 /* CurrencyExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExtensions.swift; sourceTree = "<group>"; };
+		A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
 		A77AF046245108EC8F0FCB5E /* AccountDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailView.swift; sourceTree = "<group>"; };
 		A98C146C2855A66F996339BA /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		CB0DE65022CE25F226852F23 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -116,9 +140,27 @@
 		DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		E1A4D54B054822B31C2F04F3 /* TransactionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRowView.swift; sourceTree = "<group>"; };
 		EAF762C3621015C0856200B4 /* TransferFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferFormView.swift; sourceTree = "<group>"; };
-		FA2B3C4D5E6F7A8B9C0D1E2F /* SankeyDiagramView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SankeyDiagramView.swift; sourceTree = "<group>"; };
 		F9080BF6AEE035BDBF614C5B /* FinanceApp-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FinanceApp-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		02A0C44F8D77375263716E6A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				481AF0F8385697B65F55FE64 /* Supabase in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7477CE91F2627C3412BE1588 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCD8D6C0BAD62B2F8B91ADFB /* Supabase in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		0166FB86C6861D153D96B439 /* Transfers */ = {
@@ -194,6 +236,18 @@
 			path = Transactions;
 			sourceTree = "<group>";
 		};
+		664EF7ED7A78D8156B0E6259 /* Sync */ = {
+			isa = PBXGroup;
+			children = (
+				6E0802AC8872D381C533EC2B /* EntityMapper.swift */,
+				6D0BE28E200C2BE7296C0630 /* NetworkMonitor.swift */,
+				351D8BF8152B5DBFBD50BB20 /* SupabaseManager.swift */,
+				A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */,
+				7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */,
+			);
+			path = Sync;
+			sourceTree = "<group>";
+		};
 		8237BF58B27E9B46B2F5AD36 /* Accounts */ = {
 			isa = PBXGroup;
 			children = (
@@ -213,11 +267,20 @@
 			path = Categories;
 			sourceTree = "<group>";
 		};
+		92F87C387F003D3D9BFC4BC4 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				1ADE962AC5B8A7E3297014CA /* AuthManager.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
 		9A7208E1A1DDCC0885F31A48 /* Views */ = {
 			isa = PBXGroup;
 			children = (
 				CB0DE65022CE25F226852F23 /* ContentView.swift */,
 				8237BF58B27E9B46B2F5AD36 /* Accounts */,
+				F033D283B5CC559A03153B69 /* Auth */,
 				88B5C39A015F9FAD70906EBE /* Categories */,
 				EBA5EB0E77B6C97E696A6B4F /* Dashboard */,
 				44BCB3E841FBA57AD7D78260 /* Transactions */,
@@ -231,6 +294,8 @@
 			children = (
 				0E6F49BDD3FA0A7D05AA31B6 /* CurrencyFormatter.swift */,
 				2154A0C20ECFD1DE2A295CB6 /* DefaultCategorySeeder.swift */,
+				92F87C387F003D3D9BFC4BC4 /* Auth */,
+				664EF7ED7A78D8156B0E6259 /* Sync */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -255,10 +320,18 @@
 			isa = PBXGroup;
 			children = (
 				26401E20BC231490FD3FDBAA /* DashboardView.swift */,
-				FA2B3C4D5E6F7A8B9C0D1E2F /* SankeyDiagramView.swift */,
+				8C096909BB72F234A3DAF492 /* SankeyDiagramView.swift */,
 				992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */,
 			);
 			path = Dashboard;
+			sourceTree = "<group>";
+		};
+		F033D283B5CC559A03153B69 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				353B51A60B18513F9EE9BFE7 /* SignInView.swift */,
+			);
+			path = Auth;
 			sourceTree = "<group>";
 		};
 		F721665AF863A35581A85967 /* ViewModels */ = {
@@ -299,6 +372,7 @@
 			buildPhases = (
 				551F7E9C68C66A0E42FADB25 /* Sources */,
 				02F3D4E5633D1D83679D6E69 /* Resources */,
+				02A0C44F8D77375263716E6A /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -306,6 +380,7 @@
 			);
 			name = "FinanceApp-macOS";
 			packageProductDependencies = (
+				B0435966EF9A92504DAC2187 /* Supabase */,
 			);
 			productName = "FinanceApp-macOS";
 			productReference = F9080BF6AEE035BDBF614C5B /* FinanceApp-macOS.app */;
@@ -317,6 +392,7 @@
 			buildPhases = (
 				10EF16EED12F8C5FDF07196D /* Sources */,
 				3FD81C29AAF8F0ED2147D5C7 /* Resources */,
+				7477CE91F2627C3412BE1588 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -324,6 +400,7 @@
 			);
 			name = "FinanceApp-iOS";
 			packageProductDependencies = (
+				49CD362B2E504B37A7D21D72 /* Supabase */,
 			);
 			productName = "FinanceApp-iOS";
 			productReference = 9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */;
@@ -354,7 +431,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 2630;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					179D7A42FC947BCA1864ABE5 = {
 						DevelopmentTeam = "";
@@ -373,6 +450,9 @@
 			);
 			mainGroup = 41664911853B1A777938E8B9;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				1954B48029BC5FC5D513D80D /* XCRemoteSwiftPackageReference "supabase-swift" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 29F6608C8E7C63005D680666 /* Products */;
 			projectDirPath = "";
@@ -423,6 +503,7 @@
 				79BC6BCA209688107CD14316 /* AccountFormView.swift in Sources */,
 				9357473F2F24C7AA6684A96D /* AccountListView.swift in Sources */,
 				F8E9C3A98E5D021752ABB425 /* AccountViewModel.swift in Sources */,
+				DF365EF8BEB25464C2085587 /* AuthManager.swift in Sources */,
 				6C486BC8EF541BB0A6BD883F /* Category.swift in Sources */,
 				AAF64830DAEA23ED6F839FD0 /* CategoryFormView.swift in Sources */,
 				5972B156EE38C448D71D7373 /* CategoryListView.swift in Sources */,
@@ -434,10 +515,16 @@
 				F3A437B701D9D55A7BA0F398 /* DashboardViewModel.swift in Sources */,
 				EABC40144B1628BA20FA7C40 /* DateExtensions.swift in Sources */,
 				420C0B43045C566350802946 /* DefaultCategorySeeder.swift in Sources */,
+				5030F56739C02239CC5AB862 /* EntityMapper.swift in Sources */,
 				06351BC6B19380D5A9E34EB4 /* FinanceApp.swift in Sources */,
 				6AEE97C763CD8491B6387807 /* FinanceEnums.swift in Sources */,
-				EB1A2F3C4D5E6A7B8C9D0E1F /* SankeyDiagramView.swift in Sources */,
+				48197DC18D318B1036EE5333 /* NetworkMonitor.swift in Sources */,
+				A0A8AB6407550D3F3F0B8EC1 /* SankeyDiagramView.swift in Sources */,
+				5D152F031438789FDF4C2F47 /* SignInView.swift in Sources */,
 				EAC35CEC73059EF78C3F6D58 /* SpendingByCategoryView.swift in Sources */,
+				DE8402B7FD542CAF6646E107 /* SupabaseManager.swift in Sources */,
+				21C25963DD2D0F1F621B773F /* SyncEngine.swift in Sources */,
+				735D34967E74D4C3250D7953 /* SyncMetadata.swift in Sources */,
 				7301720ADC58D0A41019896E /* Transaction.swift in Sources */,
 				D8E255602F522F4D52097FF0 /* TransactionFormView.swift in Sources */,
 				915BB4586AA9C91A8069C93E /* TransactionListView.swift in Sources */,
@@ -457,6 +544,7 @@
 				B44D2C185E5E6797AE30F849 /* AccountFormView.swift in Sources */,
 				352E734E7C9D3478D029E37D /* AccountListView.swift in Sources */,
 				4C4EB3ADE44B8376536A30E5 /* AccountViewModel.swift in Sources */,
+				3A8343BCDB65E0D61BE50A2C /* AuthManager.swift in Sources */,
 				552F866F63F2732EE43032B6 /* Category.swift in Sources */,
 				2C213950A8BB8B9B14285DF9 /* CategoryFormView.swift in Sources */,
 				87E6D9293E871B44A1B9C30C /* CategoryListView.swift in Sources */,
@@ -468,10 +556,16 @@
 				9ED468C796A72F74D81B43B6 /* DashboardViewModel.swift in Sources */,
 				A45D4A2A4B202EE6D2B862AC /* DateExtensions.swift in Sources */,
 				E944B4E946C9300859C0E4FD /* DefaultCategorySeeder.swift in Sources */,
+				0F8C724207FA8A011C97A700 /* EntityMapper.swift in Sources */,
 				1D7E2E200B4B9DFFDB70CA24 /* FinanceApp.swift in Sources */,
 				84A23B41A1064577235D0167 /* FinanceEnums.swift in Sources */,
-				1A3B4C5D6E7F8A9B0C1D2E3F /* SankeyDiagramView.swift in Sources */,
+				E25EDF3BEA78C5D1F9BD5A73 /* NetworkMonitor.swift in Sources */,
+				275AA26820F8E384A1F83022 /* SankeyDiagramView.swift in Sources */,
+				AD9EF97D4FCEDCC35EED472B /* SignInView.swift in Sources */,
 				137290AE8511E5A30C8D2C6A /* SpendingByCategoryView.swift in Sources */,
+				0479D3DA656AB2ACB0D022FD /* SupabaseManager.swift in Sources */,
+				3BFA175B8C2AA04F6325E4CC /* SyncEngine.swift in Sources */,
+				7A8AD50E4E9326E7DE22FC63 /* SyncMetadata.swift in Sources */,
 				999B4922AB6BE9AF8D3CF0F9 /* Transaction.swift in Sources */,
 				EEFAE6176EAA59BFE1844C09 /* TransactionFormView.swift in Sources */,
 				632DD410BDBB1D8FAFAA6CE9 /* TransactionListView.swift in Sources */,
@@ -565,12 +659,10 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -591,7 +683,6 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
@@ -645,7 +736,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -685,7 +775,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -713,7 +802,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -736,7 +824,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -783,12 +870,10 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -802,7 +887,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 6.0;
@@ -858,6 +942,30 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		1954B48029BC5FC5D513D80D /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase-community/supabase-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		49CD362B2E504B37A7D21D72 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1954B48029BC5FC5D513D80D /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+		B0435966EF9A92504DAC2187 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1954B48029BC5FC5D513D80D /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 2AB1CACC86CDDCD4EEDD6F2B /* Project object */;
 }

--- a/FinanceApp.xcodeproj/project.pbxproj
+++ b/FinanceApp.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		87E6D9293E871B44A1B9C30C /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9495D128EBDB2E48FC5D75 /* CategoryListView.swift */; };
 		915BB4586AA9C91A8069C93E /* TransactionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E1CB32A30167EA3D463FF7 /* TransactionListView.swift */; };
 		9357473F2F24C7AA6684A96D /* AccountListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6922A1E3A401FBC89C7CC373 /* AccountListView.swift */; };
+		959ECF429748EC7BA1D1BCBA /* SignOutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D0A46C7E82AA74BF0CF8EA /* SignOutAction.swift */; };
 		997C6A2B9ED201FDB3457EC9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967E527AF6D0FB8425DA4ACE /* Constants.swift */; };
 		999B4922AB6BE9AF8D3CF0F9 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */; };
 		9B2DFB3FEC13E0CAF57ACDB2 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26401E20BC231490FD3FDBAA /* DashboardView.swift */; };
@@ -61,6 +62,7 @@
 		B44D2C185E5E6797AE30F849 /* AccountFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAE2122E580270E6589F42A /* AccountFormView.swift */; };
 		B6B68B7738F84F0BAE3B2966 /* TransactionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A4D54B054822B31C2F04F3 /* TransactionRowView.swift */; };
 		BCD8D6C0BAD62B2F8B91ADFB /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 49CD362B2E504B37A7D21D72 /* Supabase */; };
+		BE8D1F2D22534C750DC09DE1 /* SignOutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D0A46C7E82AA74BF0CF8EA /* SignOutAction.swift */; };
 		C7D5962C41073C091B75392F /* TransactionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E328665DDADB6D117410283 /* TransactionViewModel.swift */; };
 		C835AF37AC16A905D2EB672F /* TransferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79660E617343DE13EF9FE68C /* TransferViewModel.swift */; };
 		CD9A07CD0DDCA580E2D71CC5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0DE65022CE25F226852F23 /* ContentView.swift */; };
@@ -116,11 +118,12 @@
 		3E328665DDADB6D117410283 /* TransactionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewModel.swift; sourceTree = "<group>"; };
 		49E1CB32A30167EA3D463FF7 /* TransactionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListView.swift; sourceTree = "<group>"; };
 		4EAA3B252A56C9684A046F01 /* FinanceEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceEnums.swift; sourceTree = "<group>"; };
-		5A46FAEFF21370E7E1C9FABC /* FinanceAppTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FinanceAppTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5A46FAEFF21370E7E1C9FABC /* FinanceAppTests-iOS.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "FinanceAppTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6922A1E3A401FBC89C7CC373 /* AccountListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListView.swift; sourceTree = "<group>"; };
 		6D0BE28E200C2BE7296C0630 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		6E0802AC8872D381C533EC2B /* EntityMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityMapper.swift; sourceTree = "<group>"; };
 		71036145556962D8CF8DA6BA /* DateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
+		73D0A46C7E82AA74BF0CF8EA /* SignOutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutAction.swift; sourceTree = "<group>"; };
 		79660E617343DE13EF9FE68C /* TransferViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferViewModel.swift; sourceTree = "<group>"; };
 		7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMetadata.swift; sourceTree = "<group>"; };
 		8C096909BB72F234A3DAF492 /* SankeyDiagramView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SankeyDiagramView.swift; sourceTree = "<group>"; };
@@ -177,6 +180,7 @@
 				967E527AF6D0FB8425DA4ACE /* Constants.swift */,
 				9D21D56850CF85FAB1133DF2 /* CurrencyExtensions.swift */,
 				71036145556962D8CF8DA6BA /* DateExtensions.swift */,
+				73D0A46C7E82AA74BF0CF8EA /* SignOutAction.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -431,7 +435,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 2630;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					179D7A42FC947BCA1864ABE5 = {
 						DevelopmentTeam = "";
@@ -521,6 +525,7 @@
 				48197DC18D318B1036EE5333 /* NetworkMonitor.swift in Sources */,
 				A0A8AB6407550D3F3F0B8EC1 /* SankeyDiagramView.swift in Sources */,
 				5D152F031438789FDF4C2F47 /* SignInView.swift in Sources */,
+				959ECF429748EC7BA1D1BCBA /* SignOutAction.swift in Sources */,
 				EAC35CEC73059EF78C3F6D58 /* SpendingByCategoryView.swift in Sources */,
 				DE8402B7FD542CAF6646E107 /* SupabaseManager.swift in Sources */,
 				21C25963DD2D0F1F621B773F /* SyncEngine.swift in Sources */,
@@ -562,6 +567,7 @@
 				E25EDF3BEA78C5D1F9BD5A73 /* NetworkMonitor.swift in Sources */,
 				275AA26820F8E384A1F83022 /* SankeyDiagramView.swift in Sources */,
 				AD9EF97D4FCEDCC35EED472B /* SignInView.swift in Sources */,
+				BE8D1F2D22534C750DC09DE1 /* SignOutAction.swift in Sources */,
 				137290AE8511E5A30C8D2C6A /* SpendingByCategoryView.swift in Sources */,
 				0479D3DA656AB2ACB0D022FD /* SupabaseManager.swift in Sources */,
 				3BFA175B8C2AA04F6325E4CC /* SyncEngine.swift in Sources */,
@@ -659,12 +665,10 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -685,7 +689,6 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
@@ -739,7 +742,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -779,9 +781,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = MV45ATG98E;
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -808,9 +808,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = MV45ATG98E;
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -832,7 +830,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -879,12 +876,10 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -898,7 +893,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 6.0;

--- a/FinanceApp.xcodeproj/project.pbxproj
+++ b/FinanceApp.xcodeproj/project.pbxproj
@@ -133,7 +133,7 @@
 		96B4DCFA088617AB728946AE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingByCategoryView.swift; sourceTree = "<group>"; };
 		9A85E740A87AB032DE8F2903 /* AccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewModel.swift; sourceTree = "<group>"; };
-		9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "FinanceApp-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FinanceApp-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D21D56850CF85FAB1133DF2 /* CurrencyExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExtensions.swift; sourceTree = "<group>"; };
 		A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
 		A77AF046245108EC8F0FCB5E /* AccountDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailView.swift; sourceTree = "<group>"; };
@@ -444,12 +444,6 @@
 					179D7A42FC947BCA1864ABE5 = {
 						DevelopmentTeam = "";
 					};
-					93228A74122FF530C5862FB4 = {
-						DevelopmentTeam = "";
-					};
-					AA44AD860E97EC2AD74ED23D = {
-						DevelopmentTeam = "";
-					};
 					E110A3AEDF6E1E2D3FA75FE6 = {
 						DevelopmentTeam = "";
 					};
@@ -626,6 +620,7 @@
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -634,7 +629,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -731,6 +726,7 @@
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -739,7 +735,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -787,8 +783,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -797,7 +796,8 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -810,8 +810,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -820,7 +823,8 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/FinanceApp.xcodeproj/project.pbxproj
+++ b/FinanceApp.xcodeproj/project.pbxproj
@@ -116,7 +116,7 @@
 		3E328665DDADB6D117410283 /* TransactionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewModel.swift; sourceTree = "<group>"; };
 		49E1CB32A30167EA3D463FF7 /* TransactionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListView.swift; sourceTree = "<group>"; };
 		4EAA3B252A56C9684A046F01 /* FinanceEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceEnums.swift; sourceTree = "<group>"; };
-		5A46FAEFF21370E7E1C9FABC /* FinanceAppTests-iOS.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "FinanceAppTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5A46FAEFF21370E7E1C9FABC /* FinanceAppTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FinanceAppTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6922A1E3A401FBC89C7CC373 /* AccountListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListView.swift; sourceTree = "<group>"; };
 		6D0BE28E200C2BE7296C0630 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		6E0802AC8872D381C533EC2B /* EntityMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityMapper.swift; sourceTree = "<group>"; };
@@ -431,7 +431,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					179D7A42FC947BCA1864ABE5 = {
 						DevelopmentTeam = "";
@@ -659,10 +659,12 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -683,6 +685,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
@@ -736,6 +739,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -775,7 +779,9 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = MV45ATG98E;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -802,7 +808,9 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = MV45ATG98E;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -824,6 +832,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -870,10 +879,12 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -887,6 +898,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 6.0;

--- a/FinanceApp.xcodeproj/project.pbxproj
+++ b/FinanceApp.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		6C486BC8EF541BB0A6BD883F /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30291B0B5A4EE798BF018BCA /* Category.swift */; };
 		7301720ADC58D0A41019896E /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */; };
 		735D34967E74D4C3250D7953 /* SyncMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */; };
+		75A1F6A5FBDF33E336296B04 /* SyncNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F033E700F21E7EECE9D67EEC /* SyncNotification.swift */; };
+		775BC8AB86F17D0D3605D578 /* SyncNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F033E700F21E7EECE9D67EEC /* SyncNotification.swift */; };
 		79BC6BCA209688107CD14316 /* AccountFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAE2122E580270E6589F42A /* AccountFormView.swift */; };
 		7A8AD50E4E9326E7DE22FC63 /* SyncMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */; };
 		84A23B41A1064577235D0167 /* FinanceEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAA3B252A56C9684A046F01 /* FinanceEnums.swift */; };
@@ -131,7 +133,7 @@
 		96B4DCFA088617AB728946AE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		992A734E99818CE9E2E0D230 /* SpendingByCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingByCategoryView.swift; sourceTree = "<group>"; };
 		9A85E740A87AB032DE8F2903 /* AccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewModel.swift; sourceTree = "<group>"; };
-		9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FinanceApp-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B42C8C6132B03207BCA72B6 /* FinanceApp-iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "FinanceApp-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D21D56850CF85FAB1133DF2 /* CurrencyExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExtensions.swift; sourceTree = "<group>"; };
 		A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
 		A77AF046245108EC8F0FCB5E /* AccountDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailView.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 		DDAB7F5A61C86D2F90BDCB51 /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		E1A4D54B054822B31C2F04F3 /* TransactionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRowView.swift; sourceTree = "<group>"; };
 		EAF762C3621015C0856200B4 /* TransferFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferFormView.swift; sourceTree = "<group>"; };
+		F033E700F21E7EECE9D67EEC /* SyncNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncNotification.swift; sourceTree = "<group>"; };
 		F9080BF6AEE035BDBF614C5B /* FinanceApp-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FinanceApp-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -248,6 +251,7 @@
 				351D8BF8152B5DBFBD50BB20 /* SupabaseManager.swift */,
 				A6B8C3B26E37C06A28AC5013 /* SyncEngine.swift */,
 				7E864D998BCE9A5B139A9C20 /* SyncMetadata.swift */,
+				F033E700F21E7EECE9D67EEC /* SyncNotification.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -440,6 +444,12 @@
 					179D7A42FC947BCA1864ABE5 = {
 						DevelopmentTeam = "";
 					};
+					93228A74122FF530C5862FB4 = {
+						DevelopmentTeam = "";
+					};
+					AA44AD860E97EC2AD74ED23D = {
+						DevelopmentTeam = "";
+					};
 					E110A3AEDF6E1E2D3FA75FE6 = {
 						DevelopmentTeam = "";
 					};
@@ -530,6 +540,7 @@
 				DE8402B7FD542CAF6646E107 /* SupabaseManager.swift in Sources */,
 				21C25963DD2D0F1F621B773F /* SyncEngine.swift in Sources */,
 				735D34967E74D4C3250D7953 /* SyncMetadata.swift in Sources */,
+				775BC8AB86F17D0D3605D578 /* SyncNotification.swift in Sources */,
 				7301720ADC58D0A41019896E /* Transaction.swift in Sources */,
 				D8E255602F522F4D52097FF0 /* TransactionFormView.swift in Sources */,
 				915BB4586AA9C91A8069C93E /* TransactionListView.swift in Sources */,
@@ -572,6 +583,7 @@
 				0479D3DA656AB2ACB0D022FD /* SupabaseManager.swift in Sources */,
 				3BFA175B8C2AA04F6325E4CC /* SyncEngine.swift in Sources */,
 				7A8AD50E4E9326E7DE22FC63 /* SyncMetadata.swift in Sources */,
+				75A1F6A5FBDF33E336296B04 /* SyncNotification.swift in Sources */,
 				999B4922AB6BE9AF8D3CF0F9 /* Transaction.swift in Sources */,
 				EEFAE6176EAA59BFE1844C09 /* TransactionFormView.swift in Sources */,
 				632DD410BDBB1D8FAFAA6CE9 /* TransactionListView.swift in Sources */,
@@ -614,7 +626,6 @@
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -623,7 +634,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -720,7 +731,6 @@
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -729,7 +739,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -777,11 +787,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -790,8 +797,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -804,11 +810,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FinanceApp.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MV45ATG98E;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -817,8 +820,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eduardopenedos.FinanceApp;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.financeapp.FinanceApp;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-iOS.xcscheme
+++ b/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-iOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2630"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -40,7 +41,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -63,6 +65,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,6 +88,8 @@
             ReferencedContainer = "container:FinanceApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-iOS.xcscheme
+++ b/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-iOS.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
-   version = "1.7">
+   LastUpgradeVersion = "2630"
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -41,8 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -65,8 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -88,8 +84,6 @@
             ReferencedContainer = "container:FinanceApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-macOS.xcscheme
+++ b/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-macOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2630"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -40,7 +41,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -63,6 +65,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,6 +88,8 @@
             ReferencedContainer = "container:FinanceApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-macOS.xcscheme
+++ b/FinanceApp.xcodeproj/xcshareddata/xcschemes/FinanceApp-macOS.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
-   version = "1.7">
+   LastUpgradeVersion = "2630"
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -41,8 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -65,8 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -88,8 +84,6 @@
             ReferencedContainer = "container:FinanceApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FinanceApp
 
-A native personal finance application for **macOS** and **iOS/iPadOS** built with SwiftUI, SwiftData, and CloudKit.
+A native personal finance application for **macOS** and **iOS/iPadOS** built with SwiftUI, SwiftData, and Supabase.
 
 ## Features
 
@@ -8,9 +8,11 @@ A native personal finance application for **macOS** and **iOS/iPadOS** built wit
 - **Income & expense tracking** — Record transactions with amounts, dates, notes, and categories
 - **Account transfers** — Move money between accounts with linked paired transactions
 - **Category management** — 22 default categories (15 expense, 7 income) with custom icons and colors
-- **iCloud sync** — Real-time sync across all devices via CloudKit
+- **Cross-device sync** — Real-time sync across all Apple devices via Supabase (PostgreSQL + Realtime)
+- **Apple Sign-In** — Secure authentication with row-level security per user
 - **Charts & analytics** — Spending by category (pie chart) and money flow (Sankey diagram)
 - **Multi-currency support** — 15 currencies (USD, EUR, GBP, JPY, and more)
+- **Offline-first** — Works fully offline; syncs automatically when connectivity is restored
 - **Adaptive layout** — iPad/macOS use NavigationSplitView with sidebar; iPhone uses a compact TabView
 
 ## Screenshots
@@ -22,7 +24,8 @@ _Coming soon_
 - **macOS 14.0+** / **iOS 17.0+**
 - **Xcode 16.0+**
 - **Swift 6.0**
-- An Apple Developer account (for iCloud/CloudKit sync)
+- A [Supabase](https://supabase.com) project (free tier works)
+- An Apple Developer account (for Sign in with Apple)
 
 ## Getting Started
 
@@ -33,7 +36,15 @@ git clone <repo-url>
 cd FinanceApp
 ```
 
-### 2. Generate the Xcode project
+### 2. Set up Supabase
+
+1. Create a project at [supabase.com](https://supabase.com)
+2. Run the SQL migration in the Supabase SQL editor (see `~/.claude/plans/sleepy-wondering-karp.md` for the full schema)
+3. Enable Realtime on the `accounts`, `categories`, and `transactions` tables
+4. Configure Apple Sign-In in Authentication → Providers
+5. Copy your project URL and anon key into `Sources/Utilities/Constants.swift`
+
+### 3. Generate the Xcode project
 
 The project uses [XcodeGen](https://github.com/yonaskolb/XcodeGen) to generate `FinanceApp.xcodeproj` from `project.yml`.
 
@@ -42,7 +53,7 @@ brew install xcodegen   # if not already installed
 xcodegen generate
 ```
 
-### 3. Open in Xcode
+### 4. Open in Xcode
 
 ```bash
 open FinanceApp.xcodeproj
@@ -50,9 +61,9 @@ open FinanceApp.xcodeproj
 
 Select the `FinanceApp-iOS` or `FinanceApp-macOS` scheme and run.
 
-### 4. iCloud setup
+### 5. Configure signing
 
-To enable CloudKit sync, configure your signing team in Xcode and ensure the iCloud capability is enabled with the container `iCloud.com.eduardopenedos.FinanceApp`.
+In Xcode, set your Development Team and ensure the "Sign in with Apple" capability is enabled.
 
 ## Building from the command line
 
@@ -75,7 +86,7 @@ xcodebuild build -project FinanceApp.xcodeproj \
 
 ```
 Sources/
-├── FinanceApp.swift              # App entry point, ModelContainer + CloudKit
+├── FinanceApp.swift              # App entry point, ModelContainer + Supabase setup
 ├── Models/                       # SwiftData @Model classes
 │   ├── Account.swift
 │   ├── Transaction.swift
@@ -84,12 +95,17 @@ Sources/
 ├── ViewModels/                   # @Observable business logic
 ├── Views/
 │   ├── ContentView.swift         # Adaptive root navigation
+│   ├── Auth/                     # Sign-in screen (Apple Sign-In)
 │   ├── Dashboard/                # Dashboard, Sankey diagram, spending chart
 │   ├── Accounts/                 # Account list, detail, form
 │   ├── Transactions/             # Transaction list, form, row
 │   ├── Categories/               # Category list, form
 │   └── Transfers/                # Transfer form
-├── Services/                     # CurrencyFormatter, DefaultCategorySeeder
+├── Services/
+│   ├── Auth/                     # AuthManager (Supabase + Apple Sign-In)
+│   ├── Sync/                     # SyncEngine, SupabaseManager, EntityMapper, NetworkMonitor
+│   ├── CurrencyFormatter.swift
+│   └── DefaultCategorySeeder.swift
 └── Utilities/                    # Constants, extensions
 Tests/
 └── CurrencyTests.swift
@@ -98,7 +114,9 @@ Tests/
 ## Architecture
 
 - **MVVM** — Views use `@Query` for reactive data; ViewModels handle mutations via `ModelContext`
-- **SwiftData + CloudKit** — All persistence through `@Model` classes with `.automatic` CloudKit sync
+- **SwiftData (local) + Supabase (remote)** — SwiftData is the UI's single source of truth; SyncEngine pushes/pulls to Supabase
+- **Offline-first** — Changes queue in `SyncMetadata` while offline, sync on connectivity restored
+- **Last-write-wins** — Conflict resolution based on `updated_at` timestamps
 - **Currency as Int64 cents** — Avoids floating-point precision issues (e.g. `$125.50` = `12550`)
 - **Transfers as paired transactions** — Two linked `Transaction` objects sharing a `transferId`
 - **Computed balances** — `Account.balanceInCents` is always derived from its transactions, never stored

--- a/Sources/FinanceApp.swift
+++ b/Sources/FinanceApp.swift
@@ -52,6 +52,24 @@ struct FinanceApp: App {
     private func signOut() async {
         syncEngine?.stop()
         syncEngine = nil
+
+        // Clear all local SwiftData records
+        let context = modelContainer.mainContext
+        do {
+            try context.delete(model: SyncMetadata.self)
+            try context.delete(model: Transaction.self)
+            try context.delete(model: Account.self)
+            try context.delete(model: Category.self)
+            try context.save()
+        } catch {
+            print("Failed to clear local data: \(error)")
+        }
+
+        // Reset sync/migration flags so next sign-in starts fresh
+        UserDefaults.standard.removeObject(forKey: AppConstants.lastSyncTimestampKey)
+        UserDefaults.standard.removeObject(forKey: AppConstants.migrationCompletedKey)
+        UserDefaults.standard.removeObject(forKey: AppConstants.categorySeededKey)
+
         await authManager.signOut()
     }
 

--- a/Sources/FinanceApp.swift
+++ b/Sources/FinanceApp.swift
@@ -44,8 +44,15 @@ struct FinanceApp: App {
                     )
                 }
             )
+            .environment(\.signOutAction, signOut)
         }
         .modelContainer(modelContainer)
+    }
+
+    private func signOut() async {
+        syncEngine?.stop()
+        syncEngine = nil
+        await authManager.signOut()
     }
 
     private func startSync() {

--- a/Sources/FinanceApp.swift
+++ b/Sources/FinanceApp.swift
@@ -37,6 +37,7 @@ struct FinanceApp: App {
             RootView(
                 authManager: authManager,
                 networkMonitor: networkMonitor,
+                syncEngine: syncEngine,
                 onAuthenticated: { startSync() },
                 onSeedCategories: {
                     DefaultCategorySeeder.seedIfNeeded(
@@ -68,7 +69,7 @@ struct FinanceApp: App {
         // Reset sync/migration flags so next sign-in starts fresh
         UserDefaults.standard.removeObject(forKey: AppConstants.lastSyncTimestampKey)
         UserDefaults.standard.removeObject(forKey: AppConstants.migrationCompletedKey)
-        UserDefaults.standard.removeObject(forKey: AppConstants.categorySeededKey)
+
 
         await authManager.signOut()
     }
@@ -97,6 +98,7 @@ struct FinanceApp: App {
 private struct RootView: View {
     let authManager: AuthManager
     let networkMonitor: NetworkMonitor
+    var syncEngine: SyncEngine?
     let onAuthenticated: () -> Void
     let onSeedCategories: () -> Void
 
@@ -107,8 +109,12 @@ private struct RootView: View {
             } else if authManager.isAuthenticated {
                 ContentView()
                     .onAppear {
-                        onSeedCategories()
                         onAuthenticated()
+                    }
+                    .onChange(of: syncEngine?.initialPullCompleted) { _, completed in
+                        if completed == true {
+                            onSeedCategories()
+                        }
                     }
             } else {
                 SignInView(authManager: authManager)

--- a/Sources/FinanceApp.swift
+++ b/Sources/FinanceApp.swift
@@ -1,10 +1,13 @@
 import SwiftUI
 import SwiftData
-import CoreData
 
 @main
 struct FinanceApp: App {
     let modelContainer: ModelContainer
+
+    @State private var authManager = AuthManager()
+    @State private var networkMonitor = NetworkMonitor()
+    @State private var syncEngine: SyncEngine?
 
     init() {
         do {
@@ -12,21 +15,18 @@ struct FinanceApp: App {
                 Account.self,
                 Transaction.self,
                 Category.self,
+                SyncMetadata.self,
             ])
 
             let configuration = ModelConfiguration(
                 schema: schema,
-                isStoredInMemoryOnly: false,
-                cloudKitDatabase: .automatic
+                isStoredInMemoryOnly: false
             )
 
             modelContainer = try ModelContainer(
                 for: schema,
                 configurations: [configuration]
             )
-
-            // Enable persistent history tracking for remote change detection
-            setupRemoteChangeNotifications()
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }
@@ -34,45 +34,63 @@ struct FinanceApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .onAppear {
+            RootView(
+                authManager: authManager,
+                networkMonitor: networkMonitor,
+                onAuthenticated: { startSync() },
+                onSeedCategories: {
                     DefaultCategorySeeder.seedIfNeeded(
                         modelContext: modelContainer.mainContext
                     )
                 }
+            )
         }
         .modelContainer(modelContainer)
     }
 
-    private func setupRemoteChangeNotifications() {
-        // NSPersistentStoreRemoteChange fires when CloudKit merges
-        // remote data into the local persistent store
-        NotificationCenter.default.addObserver(
-            forName: .NSPersistentStoreRemoteChange,
-            object: nil,
-            queue: .main
-        ) { _ in
-            // Merge remote changes into the main context so @Query updates
-            Task { @MainActor in
-                modelContainer.mainContext.processPendingChanges()
+    private func startSync() {
+        guard syncEngine == nil else { return }
+        let engine = SyncEngine(
+            modelContainer: modelContainer,
+            authManager: authManager,
+            networkMonitor: networkMonitor
+        )
+        syncEngine = engine
+        engine.start()
+
+        // Migrate existing local data on first sign-in
+        Task {
+            await engine.migrateLocalDataToSupabase()
+        }
+    }
+}
+
+// MARK: - Root View
+
+/// Decides whether to show the sign-in screen or the main app content
+/// based on authentication state.
+private struct RootView: View {
+    let authManager: AuthManager
+    let networkMonitor: NetworkMonitor
+    let onAuthenticated: () -> Void
+    let onSeedCategories: () -> Void
+
+    var body: some View {
+        Group {
+            if authManager.isLoading {
+                ProgressView("Loading…")
+            } else if authManager.isAuthenticated {
+                ContentView()
+                    .onAppear {
+                        onSeedCategories()
+                        onAuthenticated()
+                    }
+            } else {
+                SignInView(authManager: authManager)
             }
         }
-
-        // Also listen for CloudKit container events for error logging
-        NotificationCenter.default.addObserver(
-            forName: NSPersistentCloudKitContainer.eventChangedNotification,
-            object: nil,
-            queue: .main
-        ) { notification in
-            guard let event = notification.userInfo?[
-                NSPersistentCloudKitContainer.eventNotificationUserInfoKey
-            ] as? NSPersistentCloudKitContainer.Event else {
-                return
-            }
-
-            if let error = event.error {
-                print("CloudKit sync error: \(error.localizedDescription)")
-            }
+        .task {
+            await authManager.restoreSession()
         }
     }
 }

--- a/Sources/Services/Auth/AuthManager.swift
+++ b/Sources/Services/Auth/AuthManager.swift
@@ -1,0 +1,152 @@
+import Foundation
+import AuthenticationServices
+import Supabase
+import Observation
+import CryptoKit
+
+// MARK: - Authentication Manager
+
+/// Manages Supabase authentication with Apple Sign-In.
+/// Exposes the current user session so the UI can gate access
+/// and the SyncEngine can attach user_id to records.
+@Observable
+@MainActor
+final class AuthManager {
+
+    // MARK: - Properties
+
+    private(set) var currentUser: User?
+    private(set) var isAuthenticated: Bool = false
+    private(set) var isLoading: Bool = true
+    private(set) var errorMessage: String?
+
+    private let client = SupabaseManager.client
+
+    /// The current nonce used for Apple Sign-In (needed for token validation)
+    private var currentNonce: String?
+
+    // MARK: - Computed
+
+    var userId: UUID? {
+        currentUser?.id
+    }
+
+    // MARK: - Session Restoration
+
+    /// Call on app launch to restore an existing session.
+    func restoreSession() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let session = try await client.auth.session
+            currentUser = session.user
+            isAuthenticated = true
+        } catch {
+            // No existing session — user needs to sign in
+            currentUser = nil
+            isAuthenticated = false
+        }
+    }
+
+    // MARK: - Apple Sign-In
+
+    /// Generates the nonce and returns an ASAuthorizationAppleIDRequest
+    /// configured for use with Supabase Auth.
+    func createAppleIDRequest() -> ASAuthorizationAppleIDRequest {
+        let provider = ASAuthorizationAppleIDProvider()
+        let request = provider.createRequest()
+        request.requestedScopes = [.email, .fullName]
+
+        let nonce = generateNonce()
+        currentNonce = nonce
+        request.nonce = sha256(nonce)
+
+        return request
+    }
+
+    /// Handle the authorization result from ASAuthorizationController.
+    func handleAppleSignIn(result: Result<ASAuthorization, Error>) async {
+        errorMessage = nil
+
+        switch result {
+        case .success(let authorization):
+            guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                  let identityTokenData = credential.identityToken,
+                  let identityToken = String(data: identityTokenData, encoding: .utf8),
+                  let nonce = currentNonce else {
+                errorMessage = "Failed to get Apple ID credentials."
+                return
+            }
+
+            do {
+                let session = try await client.auth.signInWithIdToken(
+                    credentials: .init(
+                        provider: .apple,
+                        idToken: identityToken,
+                        nonce: nonce
+                    )
+                )
+                currentUser = session.user
+                isAuthenticated = true
+                currentNonce = nil
+            } catch {
+                errorMessage = "Sign in failed: \(error.localizedDescription)"
+            }
+
+        case .failure(let error):
+            // User cancelled is not an error we need to show
+            if (error as? ASAuthorizationError)?.code == .canceled {
+                return
+            }
+            errorMessage = "Apple Sign-In failed: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Sign Out
+
+    func signOut() async {
+        do {
+            try await client.auth.signOut()
+            currentUser = nil
+            isAuthenticated = false
+        } catch {
+            errorMessage = "Sign out failed: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Nonce Helpers
+
+    private func generateNonce(length: Int = 32) -> String {
+        let charset = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0..<16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce: \(errorCode)")
+                }
+                return random
+            }
+
+            for random in randoms {
+                if remainingLength == 0 { break }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashed = SHA256.hash(data: inputData)
+        return hashed.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/Services/DefaultCategorySeeder.swift
+++ b/Sources/Services/DefaultCategorySeeder.swift
@@ -40,6 +40,8 @@ struct DefaultCategorySeeder {
             ("Other", "ellipsis.circle", "#9E9E9E"),
         ]
 
+        var insertedCategories: [Category] = []
+
         for (name, icon, color) in expenseCategories {
             let category = Category(
                 name: name,
@@ -49,6 +51,7 @@ struct DefaultCategorySeeder {
                 isDefault: true
             )
             modelContext.insert(category)
+            insertedCategories.append(category)
         }
 
         for (name, icon, color) in incomeCategories {
@@ -60,10 +63,19 @@ struct DefaultCategorySeeder {
                 isDefault: true
             )
             modelContext.insert(category)
+            insertedCategories.append(category)
         }
 
         do {
             try modelContext.save()
+            let changes = insertedCategories.map { category in
+                SyncNotification.Change(
+                    entityType: .category,
+                    entityId: category.id,
+                    changeType: .insert
+                )
+            }
+            SyncNotification.post(changes: changes)
         } catch {
             print("Failed to seed default categories: \(error)")
         }

--- a/Sources/Services/DefaultCategorySeeder.swift
+++ b/Sources/Services/DefaultCategorySeeder.swift
@@ -5,8 +5,12 @@ struct DefaultCategorySeeder {
     private init() {}
 
     static func seedIfNeeded(modelContext: ModelContext) {
-        let hasSeeded = UserDefaults.standard.bool(forKey: AppConstants.categorySeededKey)
-        guard !hasSeeded else { return }
+        // Check the database for existing categories instead of a device-local flag.
+        // This prevents duplicate seeding across devices — if categories were already
+        // pulled from Supabase sync, we skip seeding entirely.
+        let descriptor = FetchDescriptor<Category>()
+        let existingCount = (try? modelContext.fetchCount(descriptor)) ?? 0
+        guard existingCount == 0 else { return }
 
         let expenseCategories: [(String, String, String)] = [
             ("Food & Dining", "fork.knife", "#FF6B6B"),
@@ -60,7 +64,6 @@ struct DefaultCategorySeeder {
 
         do {
             try modelContext.save()
-            UserDefaults.standard.set(true, forKey: AppConstants.categorySeededKey)
         } catch {
             print("Failed to seed default categories: \(error)")
         }

--- a/Sources/Services/Sync/EntityMapper.swift
+++ b/Sources/Services/Sync/EntityMapper.swift
@@ -1,0 +1,254 @@
+import Foundation
+import SwiftData
+
+// MARK: - Supabase Row DTOs (Codable)
+
+/// Data transfer objects matching the PostgreSQL schema.
+/// Used for serializing to/from Supabase PostgREST.
+
+struct SupabaseAccountRow: Codable, Sendable {
+    let id: String
+    let userId: String
+    let name: String
+    let accountType: String
+    let currency: String
+    let icon: String
+    let createdDate: String
+    let updatedAt: String
+    let deletedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case name
+        case accountType = "account_type"
+        case currency
+        case icon
+        case createdDate = "created_date"
+        case updatedAt = "updated_at"
+        case deletedAt = "deleted_at"
+    }
+}
+
+struct SupabaseTransactionRow: Codable, Sendable {
+    let id: String
+    let userId: String
+    let amountInCents: Int64
+    let transactionType: String
+    let date: String
+    let notes: String
+    let transferId: String?
+    let accountId: String?
+    let categoryId: String?
+    let updatedAt: String
+    let deletedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case amountInCents = "amount_in_cents"
+        case transactionType = "transaction_type"
+        case date
+        case notes
+        case transferId = "transfer_id"
+        case accountId = "account_id"
+        case categoryId = "category_id"
+        case updatedAt = "updated_at"
+        case deletedAt = "deleted_at"
+    }
+}
+
+struct SupabaseCategoryRow: Codable, Sendable {
+    let id: String
+    let userId: String
+    let name: String
+    let icon: String
+    let colorHex: String
+    let transactionType: String
+    let isDefault: Bool
+    let updatedAt: String
+    let deletedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case name
+        case icon
+        case colorHex = "color_hex"
+        case transactionType = "transaction_type"
+        case isDefault = "is_default"
+        case updatedAt = "updated_at"
+        case deletedAt = "deleted_at"
+    }
+}
+
+// MARK: - Soft Delete DTO
+
+struct SoftDeleteRow: Codable, Sendable {
+    let deletedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case deletedAt = "deleted_at"
+    }
+}
+
+// MARK: - Entity Mapper
+
+/// Bidirectional mapping between SwiftData @Model objects and
+/// Supabase Codable row DTOs.
+enum EntityMapper {
+
+    // MARK: - Date Formatting
+
+    private static func nowISO() -> String {
+        ISO8601DateFormatter().string(from: Date.now)
+    }
+
+    static func parseDate(_ string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+
+    private static func formatDate(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    // MARK: - Account
+
+    static func toRow(account: Account, userId: UUID) -> SupabaseAccountRow {
+        SupabaseAccountRow(
+            id: account.id.uuidString,
+            userId: userId.uuidString,
+            name: account.name,
+            accountType: account.accountType,
+            currency: account.currency,
+            icon: account.icon,
+            createdDate: formatDate(account.createdDate),
+            updatedAt: nowISO(),
+            deletedAt: nil
+        )
+    }
+
+    static func updateAccount(_ account: Account, from row: SupabaseAccountRow) {
+        account.name = row.name
+        account.accountType = row.accountType
+        account.currency = row.currency
+        account.icon = row.icon
+        if let date = parseDate(row.createdDate) {
+            account.createdDate = date
+        }
+    }
+
+    static func createAccount(from row: SupabaseAccountRow) -> Account? {
+        guard UUID(uuidString: row.id) != nil else { return nil }
+        let accountType = AccountType(rawValue: row.accountType) ?? .checking
+        let currency = SupportedCurrency(rawValue: row.currency) ?? .usd
+        let account = Account(
+            name: row.name,
+            accountType: accountType,
+            currency: currency,
+            icon: row.icon
+        )
+        // Override the auto-generated id with the remote one
+        if let id = UUID(uuidString: row.id) {
+            account.id = id
+        }
+        if let date = parseDate(row.createdDate) {
+            account.createdDate = date
+        }
+        return account
+    }
+
+    // MARK: - Transaction
+
+    static func toRow(transaction: Transaction, userId: UUID) -> SupabaseTransactionRow {
+        SupabaseTransactionRow(
+            id: transaction.id.uuidString,
+            userId: userId.uuidString,
+            amountInCents: transaction.amountInCents,
+            transactionType: transaction.transactionType,
+            date: formatDate(transaction.date),
+            notes: transaction.notes,
+            transferId: transaction.transferId,
+            accountId: transaction.account?.id.uuidString,
+            categoryId: transaction.category?.id.uuidString,
+            updatedAt: nowISO(),
+            deletedAt: nil
+        )
+    }
+
+    static func updateTransaction(
+        _ transaction: Transaction,
+        from row: SupabaseTransactionRow
+    ) {
+        transaction.amountInCents = row.amountInCents
+        transaction.transactionType = row.transactionType
+        if let date = parseDate(row.date) {
+            transaction.date = date
+        }
+        transaction.notes = row.notes
+        transaction.transferId = row.transferId
+    }
+
+    static func createTransaction(from row: SupabaseTransactionRow) -> Transaction? {
+        guard UUID(uuidString: row.id) != nil else { return nil }
+        let type = TransactionType(rawValue: row.transactionType) ?? .expense
+        let date = parseDate(row.date) ?? Date.now
+        let transaction = Transaction(
+            amountInCents: row.amountInCents,
+            transactionType: type,
+            date: date,
+            notes: row.notes,
+            transferId: row.transferId,
+            account: nil,
+            category: nil
+        )
+        if let id = UUID(uuidString: row.id) {
+            transaction.id = id
+        }
+        return transaction
+    }
+
+    // MARK: - Category
+
+    static func toRow(category: Category, userId: UUID) -> SupabaseCategoryRow {
+        SupabaseCategoryRow(
+            id: category.id.uuidString,
+            userId: userId.uuidString,
+            name: category.name,
+            icon: category.icon,
+            colorHex: category.colorHex,
+            transactionType: category.transactionType,
+            isDefault: category.isDefault,
+            updatedAt: nowISO(),
+            deletedAt: nil
+        )
+    }
+
+    static func updateCategory(_ category: Category, from row: SupabaseCategoryRow) {
+        category.name = row.name
+        category.icon = row.icon
+        category.colorHex = row.colorHex
+        category.transactionType = row.transactionType
+        category.isDefault = row.isDefault
+    }
+
+    static func createCategory(from row: SupabaseCategoryRow) -> Category? {
+        guard UUID(uuidString: row.id) != nil else { return nil }
+        let type = TransactionType(rawValue: row.transactionType) ?? .expense
+        let category = Category(
+            name: row.name,
+            icon: row.icon,
+            colorHex: row.colorHex,
+            transactionType: type,
+            isDefault: row.isDefault
+        )
+        if let id = UUID(uuidString: row.id) {
+            category.id = id
+        }
+        return category
+    }
+}

--- a/Sources/Services/Sync/NetworkMonitor.swift
+++ b/Sources/Services/Sync/NetworkMonitor.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Network
+import Observation
+
+// MARK: - Network Connectivity Monitor
+
+/// Wraps NWPathMonitor to provide an observable connectivity state.
+/// Used by SyncEngine to determine when to push/pull changes.
+@Observable
+@MainActor
+final class NetworkMonitor: Sendable {
+
+    // MARK: - Properties
+
+    private(set) var isConnected: Bool = true
+    private(set) var connectionType: ConnectionType = .unknown
+
+    private let monitor: NWPathMonitor
+    private let queue = DispatchQueue(label: "com.financeapp.networkmonitor")
+
+    // MARK: - Types
+
+    enum ConnectionType: String, Sendable {
+        case wifi
+        case cellular
+        case wiredEthernet
+        case unknown
+    }
+
+    // MARK: - Lifecycle
+
+    init() {
+        monitor = NWPathMonitor()
+        startMonitoring()
+    }
+
+    // MARK: - Monitoring
+
+    private func startMonitoring() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let satisfied = path.status == .satisfied
+            let wifi = path.usesInterfaceType(.wifi)
+            let cellular = path.usesInterfaceType(.cellular)
+            let ethernet = path.usesInterfaceType(.wiredEthernet)
+
+            Task { @MainActor in
+                self?.applyConnectionStatus(
+                    satisfied: satisfied,
+                    wifi: wifi,
+                    cellular: cellular,
+                    ethernet: ethernet
+                )
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    private func applyConnectionStatus(
+        satisfied: Bool,
+        wifi: Bool,
+        cellular: Bool,
+        ethernet: Bool
+    ) {
+        let wasConnected = isConnected
+        isConnected = satisfied
+
+        if wifi {
+            connectionType = .wifi
+        } else if cellular {
+            connectionType = .cellular
+        } else if ethernet {
+            connectionType = .wiredEthernet
+        } else {
+            connectionType = .unknown
+        }
+
+        if !wasConnected && isConnected {
+            NotificationCenter.default.post(
+                name: .connectivityRestored,
+                object: nil
+            )
+        }
+    }
+
+    func stopMonitoring() {
+        monitor.cancel()
+    }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    static let connectivityRestored = Notification.Name("connectivityRestored")
+}

--- a/Sources/Services/Sync/SupabaseManager.swift
+++ b/Sources/Services/Sync/SupabaseManager.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Supabase
+
+// MARK: - Supabase Client Singleton
+
+/// Provides a single shared Supabase client instance configured from AppConstants.
+/// All Supabase interactions (auth, database, realtime) go through this client.
+enum SupabaseManager {
+
+    static let client = SupabaseClient(
+        supabaseURL: AppConstants.supabaseURL,
+        supabaseKey: AppConstants.supabaseAnonKey
+    )
+}

--- a/Sources/Services/Sync/SyncEngine.swift
+++ b/Sources/Services/Sync/SyncEngine.swift
@@ -26,6 +26,7 @@ final class SyncEngine {
     private(set) var isSyncing: Bool = false
     private(set) var lastSyncDate: Date?
     private(set) var syncError: String?
+    private(set) var initialPullCompleted: Bool = false
 
     private var realtimeChannel: RealtimeChannelV2?
     private var pushDebounceTask: Task<Void, Never>?
@@ -267,6 +268,7 @@ final class SyncEngine {
         guard authManager.isAuthenticated,
               let userId = authManager.userId,
               networkMonitor.isConnected else {
+            initialPullCompleted = true
             return
         }
 
@@ -311,10 +313,12 @@ final class SyncEngine {
             lastSyncDate = Date.now
             isSyncing = false
             isPulling = false
+            initialPullCompleted = true
 
         } catch {
             isSyncing = false
             isPulling = false
+            initialPullCompleted = true
             syncError = "Pull failed: \(error.localizedDescription)"
         }
     }

--- a/Sources/Services/Sync/SyncEngine.swift
+++ b/Sources/Services/Sync/SyncEngine.swift
@@ -1,0 +1,589 @@
+import Foundation
+import SwiftData
+import CoreData
+import Supabase
+import Observation
+
+// MARK: - Sync Engine
+
+/// Orchestrates bidirectional sync between local SwiftData and remote Supabase.
+///
+/// - **Push**: Observes local saves via NSManagedObjectContext notifications,
+///   queues changes in SyncMetadata, and upserts to Supabase.
+/// - **Pull**: Subscribes to Supabase Realtime for live updates and performs
+///   full pulls on first login / connectivity restoration.
+/// - **Conflict resolution**: Last-write-wins based on `updated_at`.
+@Observable
+@MainActor
+final class SyncEngine {
+
+    // MARK: - Properties
+
+    private let modelContainer: ModelContainer
+    private let authManager: AuthManager
+    private let networkMonitor: NetworkMonitor
+    private let client = SupabaseManager.client
+
+    private(set) var isSyncing: Bool = false
+    private(set) var lastSyncDate: Date?
+    private(set) var syncError: String?
+
+    private var realtimeChannel: RealtimeChannelV2?
+    private var pushDebounceTask: Task<Void, Never>?
+    private var saveObserver: NSObjectProtocol?
+    private var connectivityObserver: NSObjectProtocol?
+
+    /// Flag to prevent re-entrant sync from save notifications
+    /// triggered by our own pull writes.
+    private var isPulling: Bool = false
+
+    // MARK: - Init
+
+    init(
+        modelContainer: ModelContainer,
+        authManager: AuthManager,
+        networkMonitor: NetworkMonitor
+    ) {
+        self.modelContainer = modelContainer
+        self.authManager = authManager
+        self.networkMonitor = networkMonitor
+    }
+
+    // MARK: - Start / Stop
+
+    func start() {
+        observeLocalSaves()
+        observeConnectivity()
+
+        Task {
+            await subscribeToRealtime()
+            await performFullPull()
+        }
+    }
+
+    func stop() {
+        if let saveObserver {
+            NotificationCenter.default.removeObserver(saveObserver)
+        }
+        if let connectivityObserver {
+            NotificationCenter.default.removeObserver(connectivityObserver)
+        }
+        pushDebounceTask?.cancel()
+
+        Task {
+            await realtimeChannel?.unsubscribe()
+        }
+    }
+
+    // MARK: - Local Save Observation
+
+    private func observeLocalSaves() {
+        saveObserver = NotificationCenter.default.addObserver(
+            forName: .NSManagedObjectContextDidSave,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            // Extract data on the calling thread before crossing isolation
+            let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>
+            let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>
+            let deletedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject>
+
+            let inserted = Self.extractEntityIds(from: insertedObjects, changeType: .insert)
+            let updated = Self.extractEntityIds(from: updatedObjects, changeType: .update)
+            let deleted = Self.extractEntityIds(from: deletedObjects, changeType: .delete)
+
+            let allChanges = inserted + updated + deleted
+
+            Task { @MainActor in
+                self?.handleExtractedChanges(allChanges)
+            }
+        }
+    }
+
+    private func handleExtractedChanges(_ changes: [TrackedChange]) {
+        guard !isPulling else { return }
+        guard !changes.isEmpty else { return }
+
+        let context = modelContainer.mainContext
+
+        for change in changes {
+            let metadata = SyncMetadata(
+                entityType: change.entityType,
+                entityId: change.entityId,
+                changeType: change.changeType
+            )
+            context.insert(metadata)
+        }
+
+        try? context.save()
+        schedulePush()
+    }
+
+    private struct TrackedChange: Sendable {
+        let entityType: SyncMetadata.EntityType
+        let entityId: UUID
+        let changeType: SyncMetadata.ChangeType
+    }
+
+    nonisolated private static func extractEntityIds(
+        from objects: Set<NSManagedObject>?,
+        changeType: SyncMetadata.ChangeType
+    ) -> [TrackedChange] {
+        guard let managedObjects = objects else {
+            return []
+        }
+
+        return managedObjects.compactMap { (object: NSManagedObject) -> TrackedChange? in
+            let entityName = object.entity.name ?? ""
+
+            let entityType: SyncMetadata.EntityType
+            switch entityName {
+            case "Account": entityType = .account
+            case "Transaction": entityType = .transaction
+            case "Category": entityType = .category
+            default: return nil
+            }
+
+            guard let id = object.value(forKey: "id") as? UUID else { return nil }
+
+            return TrackedChange(
+                entityType: entityType,
+                entityId: id,
+                changeType: changeType
+            )
+        }
+    }
+
+    // MARK: - Push (Local → Remote)
+
+    private func schedulePush() {
+        pushDebounceTask?.cancel()
+        pushDebounceTask = Task {
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            await pushPendingChanges()
+        }
+    }
+
+    func pushPendingChanges() async {
+        guard authManager.isAuthenticated,
+              let userId = authManager.userId,
+              networkMonitor.isConnected else {
+            return
+        }
+
+        let context = modelContainer.mainContext
+
+        do {
+            let descriptor = FetchDescriptor<SyncMetadata>(
+                predicate: #Predicate<SyncMetadata> { !$0.isSynced },
+                sortBy: [SortDescriptor(\.timestamp)]
+            )
+            let pendingChanges = try context.fetch(descriptor)
+            guard !pendingChanges.isEmpty else { return }
+
+            isSyncing = true
+            syncError = nil
+
+            for metadata in pendingChanges {
+                do {
+                    try await pushSingleChange(metadata, userId: userId, context: context)
+                    metadata.isSynced = true
+                } catch {
+                    metadata.retryCount += 1
+                    print("Sync push failed for \(metadata.entityType)/\(metadata.entityId): \(error)")
+
+                    if metadata.retryCount >= 5 {
+                        metadata.isSynced = true
+                        syncError = "Some changes failed to sync after multiple retries."
+                    }
+                }
+            }
+
+            try? context.save()
+            cleanupSyncedMetadata(context: context)
+
+            isSyncing = false
+            lastSyncDate = Date.now
+
+        } catch {
+            isSyncing = false
+            syncError = "Push failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func pushSingleChange(
+        _ metadata: SyncMetadata,
+        userId: UUID,
+        context: ModelContext
+    ) async throws {
+        let entityIdStr = metadata.entityId
+
+        switch metadata.changeTypeEnum {
+        case .insert, .update:
+            try await pushUpsert(
+                entityType: metadata.entityTypeEnum,
+                entityIdStr: entityIdStr,
+                userId: userId,
+                context: context
+            )
+        case .delete:
+            try await pushDelete(
+                entityType: metadata.entityTypeEnum,
+                entityIdStr: entityIdStr
+            )
+        }
+    }
+
+    private func pushUpsert(
+        entityType: SyncMetadata.EntityType,
+        entityIdStr: String,
+        userId: UUID,
+        context: ModelContext
+    ) async throws {
+        guard let entityId = UUID(uuidString: entityIdStr) else { return }
+
+        switch entityType {
+        case .account:
+            let descriptor = FetchDescriptor<Account>(
+                predicate: #Predicate<Account> { $0.id == entityId }
+            )
+            guard let account = try context.fetch(descriptor).first else { return }
+            let row = EntityMapper.toRow(account: account, userId: userId)
+            try await client.from("accounts").upsert(row).execute()
+
+        case .transaction:
+            let descriptor = FetchDescriptor<Transaction>(
+                predicate: #Predicate<Transaction> { $0.id == entityId }
+            )
+            guard let transaction = try context.fetch(descriptor).first else { return }
+            let row = EntityMapper.toRow(transaction: transaction, userId: userId)
+            try await client.from("transactions").upsert(row).execute()
+
+        case .category:
+            let descriptor = FetchDescriptor<Category>(
+                predicate: #Predicate<Category> { $0.id == entityId }
+            )
+            guard let category = try context.fetch(descriptor).first else { return }
+            let row = EntityMapper.toRow(category: category, userId: userId)
+            try await client.from("categories").upsert(row).execute()
+        }
+    }
+
+    private func pushDelete(
+        entityType: SyncMetadata.EntityType,
+        entityIdStr: String
+    ) async throws {
+        let table: String
+        switch entityType {
+        case .account: table = "accounts"
+        case .transaction: table = "transactions"
+        case .category: table = "categories"
+        }
+
+        let softDelete = SoftDeleteRow(
+            deletedAt: ISO8601DateFormatter().string(from: Date.now)
+        )
+        try await client.from(table)
+            .update(softDelete)
+            .eq("id", value: entityIdStr)
+            .execute()
+    }
+
+    private func cleanupSyncedMetadata(context: ModelContext) {
+        do {
+            let descriptor = FetchDescriptor<SyncMetadata>(
+                predicate: #Predicate<SyncMetadata> { $0.isSynced }
+            )
+            let synced = try context.fetch(descriptor)
+            for item in synced {
+                context.delete(item)
+            }
+            try? context.save()
+        } catch {
+            // Non-critical cleanup
+        }
+    }
+
+    // MARK: - Pull (Remote → Local)
+
+    func performFullPull() async {
+        guard authManager.isAuthenticated,
+              let userId = authManager.userId,
+              networkMonitor.isConnected else {
+            return
+        }
+
+        isSyncing = true
+        isPulling = true
+        syncError = nil
+
+        let context = modelContainer.mainContext
+        let lastSync = UserDefaults.standard.object(
+            forKey: AppConstants.lastSyncTimestampKey
+        ) as? Date
+
+        do {
+            // Pull accounts
+            let accountRows: [SupabaseAccountRow] = try await fetchRows(
+                table: "accounts", userId: userId, since: lastSync
+            )
+            for row in accountRows {
+                handlePulledAccount(row, context: context)
+            }
+
+            // Pull categories
+            let categoryRows: [SupabaseCategoryRow] = try await fetchRows(
+                table: "categories", userId: userId, since: lastSync
+            )
+            for row in categoryRows {
+                handlePulledCategory(row, context: context)
+            }
+
+            // Pull transactions (after accounts + categories for relationship linking)
+            let transactionRows: [SupabaseTransactionRow] = try await fetchRows(
+                table: "transactions", userId: userId, since: lastSync
+            )
+            for row in transactionRows {
+                try handlePulledTransaction(row, context: context)
+            }
+
+            try? context.save()
+            context.processPendingChanges()
+
+            UserDefaults.standard.set(Date.now, forKey: AppConstants.lastSyncTimestampKey)
+            lastSyncDate = Date.now
+            isSyncing = false
+            isPulling = false
+
+        } catch {
+            isSyncing = false
+            isPulling = false
+            syncError = "Pull failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func fetchRows<T: Decodable>(
+        table: String,
+        userId: UUID,
+        since: Date?
+    ) async throws -> [T] {
+        var query = client.from(table)
+            .select()
+            .eq("user_id", value: userId.uuidString)
+
+        if let since {
+            let sinceStr = ISO8601DateFormatter().string(from: since)
+            query = query.gte("updated_at", value: sinceStr)
+        }
+
+        return try await query.execute().value
+    }
+
+    // MARK: - Pull Handlers
+
+    private func handlePulledAccount(_ row: SupabaseAccountRow, context: ModelContext) {
+        let isDeleted = row.deletedAt != nil
+
+        if let existing = findAccount(id: row.id, context: context) {
+            if isDeleted {
+                context.delete(existing)
+            } else if shouldAcceptRemote(remoteUpdatedAt: row.updatedAt) {
+                EntityMapper.updateAccount(existing, from: row)
+            }
+        } else if !isDeleted {
+            if let newAccount = EntityMapper.createAccount(from: row) {
+                context.insert(newAccount)
+            }
+        }
+    }
+
+    private func handlePulledCategory(_ row: SupabaseCategoryRow, context: ModelContext) {
+        let isDeleted = row.deletedAt != nil
+
+        if let existing = findCategory(id: row.id, context: context) {
+            if isDeleted {
+                context.delete(existing)
+            } else {
+                EntityMapper.updateCategory(existing, from: row)
+            }
+        } else if !isDeleted {
+            if let newCategory = EntityMapper.createCategory(from: row) {
+                context.insert(newCategory)
+            }
+        }
+    }
+
+    private func handlePulledTransaction(
+        _ row: SupabaseTransactionRow,
+        context: ModelContext
+    ) throws {
+        let isDeleted = row.deletedAt != nil
+
+        if let existing = findTransaction(id: row.id, context: context) {
+            if isDeleted {
+                context.delete(existing)
+            } else {
+                EntityMapper.updateTransaction(existing, from: row)
+                // Re-link relationships if changed
+                if let accountId = row.accountId {
+                    existing.account = findAccount(id: accountId, context: context)
+                }
+                if let categoryId = row.categoryId {
+                    existing.category = findCategory(id: categoryId, context: context)
+                }
+            }
+        } else if !isDeleted {
+            if let newTransaction = EntityMapper.createTransaction(from: row) {
+                if let accountId = row.accountId {
+                    newTransaction.account = findAccount(id: accountId, context: context)
+                }
+                if let categoryId = row.categoryId {
+                    newTransaction.category = findCategory(id: categoryId, context: context)
+                }
+                context.insert(newTransaction)
+            }
+        }
+    }
+
+    // MARK: - Realtime Subscription
+
+    private func subscribeToRealtime() async {
+        guard let userId = authManager.userId else { return }
+
+        let channel = client.realtimeV2.channel(
+            "user-sync-\(userId.uuidString.prefix(8))"
+        )
+
+        let accountChanges = channel.postgresChange(
+            AnyAction.self,
+            schema: "public",
+            table: "accounts",
+            filter: "user_id=eq.\(userId.uuidString)"
+        )
+
+        let categoryChanges = channel.postgresChange(
+            AnyAction.self,
+            schema: "public",
+            table: "categories",
+            filter: "user_id=eq.\(userId.uuidString)"
+        )
+
+        let transactionChanges = channel.postgresChange(
+            AnyAction.self,
+            schema: "public",
+            table: "transactions",
+            filter: "user_id=eq.\(userId.uuidString)"
+        )
+
+        await channel.subscribe()
+        realtimeChannel = channel
+
+        Task {
+            for await _ in accountChanges {
+                await performFullPull()
+            }
+        }
+        Task {
+            for await _ in categoryChanges {
+                await performFullPull()
+            }
+        }
+        Task {
+            for await _ in transactionChanges {
+                await performFullPull()
+            }
+        }
+    }
+
+    // MARK: - Connectivity
+
+    private func observeConnectivity() {
+        connectivityObserver = NotificationCenter.default.addObserver(
+            forName: .connectivityRestored,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                await self?.pushPendingChanges()
+                await self?.performFullPull()
+            }
+        }
+    }
+
+    // MARK: - Lookup Helpers
+
+    private func findAccount(id: String?, context: ModelContext) -> Account? {
+        guard let idStr = id, let uuid = UUID(uuidString: idStr) else { return nil }
+        let descriptor = FetchDescriptor<Account>(
+            predicate: #Predicate<Account> { $0.id == uuid }
+        )
+        return try? context.fetch(descriptor).first
+    }
+
+    private func findCategory(id: String?, context: ModelContext) -> Category? {
+        guard let idStr = id, let uuid = UUID(uuidString: idStr) else { return nil }
+        let descriptor = FetchDescriptor<Category>(
+            predicate: #Predicate<Category> { $0.id == uuid }
+        )
+        return try? context.fetch(descriptor).first
+    }
+
+    private func findTransaction(id: String?, context: ModelContext) -> Transaction? {
+        guard let idStr = id, let uuid = UUID(uuidString: idStr) else { return nil }
+        let descriptor = FetchDescriptor<Transaction>(
+            predicate: #Predicate<Transaction> { $0.id == uuid }
+        )
+        return try? context.fetch(descriptor).first
+    }
+
+    // MARK: - Conflict Resolution
+
+    private func shouldAcceptRemote(remoteUpdatedAt: String) -> Bool {
+        // Last-write-wins: always accept remote for now
+        // The server's updated_at trigger ensures accurate timestamps
+        true
+    }
+
+    // MARK: - Initial Migration
+
+    func migrateLocalDataToSupabase() async {
+        guard let userId = authManager.userId else { return }
+
+        let alreadyMigrated = UserDefaults.standard.bool(
+            forKey: AppConstants.migrationCompletedKey
+        )
+        guard !alreadyMigrated else { return }
+
+        isSyncing = true
+        let context = modelContainer.mainContext
+
+        do {
+            let accounts = try context.fetch(FetchDescriptor<Account>())
+            for account in accounts {
+                let row = EntityMapper.toRow(account: account, userId: userId)
+                try await client.from("accounts").upsert(row).execute()
+            }
+
+            let categories = try context.fetch(FetchDescriptor<Category>())
+            for category in categories {
+                let row = EntityMapper.toRow(category: category, userId: userId)
+                try await client.from("categories").upsert(row).execute()
+            }
+
+            let transactions = try context.fetch(FetchDescriptor<Transaction>())
+            for transaction in transactions {
+                let row = EntityMapper.toRow(transaction: transaction, userId: userId)
+                try await client.from("transactions").upsert(row).execute()
+            }
+
+            UserDefaults.standard.set(true, forKey: AppConstants.migrationCompletedKey)
+            isSyncing = false
+            lastSyncDate = Date.now
+
+        } catch {
+            isSyncing = false
+            syncError = "Migration failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Sources/Services/Sync/SyncEngine.swift
+++ b/Sources/Services/Sync/SyncEngine.swift
@@ -139,10 +139,16 @@ final class SyncEngine {
             let pendingChanges = try context.fetch(descriptor)
             guard !pendingChanges.isEmpty else { return }
 
+            // Sort by entity type to satisfy FK dependencies:
+            // accounts first, then categories, then transactions.
+            let sortedChanges = pendingChanges.sorted {
+                $0.entityTypeEnum.pushOrder < $1.entityTypeEnum.pushOrder
+            }
+
             isSyncing = true
             syncError = nil
 
-            for metadata in pendingChanges {
+            for metadata in sortedChanges {
                 do {
                     try await pushSingleChange(metadata, userId: userId, context: context)
                     metadata.isSynced = true

--- a/Sources/Services/Sync/SyncEngine.swift
+++ b/Sources/Services/Sync/SyncEngine.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SwiftData
-import CoreData
 import Supabase
 import Observation
 
@@ -79,28 +78,20 @@ final class SyncEngine {
 
     private func observeLocalSaves() {
         saveObserver = NotificationCenter.default.addObserver(
-            forName: .NSManagedObjectContextDidSave,
+            forName: SyncNotification.didSaveLocalData,
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            // Extract data on the calling thread before crossing isolation
-            let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>
-            let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>
-            let deletedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject>
-
-            let inserted = Self.extractEntityIds(from: insertedObjects, changeType: .insert)
-            let updated = Self.extractEntityIds(from: updatedObjects, changeType: .update)
-            let deleted = Self.extractEntityIds(from: deletedObjects, changeType: .delete)
-
-            let allChanges = inserted + updated + deleted
+            let changes = notification.userInfo?[SyncNotification.changesKey]
+                as? [SyncNotification.Change] ?? []
 
             Task { @MainActor in
-                self?.handleExtractedChanges(allChanges)
+                self?.handleNotifiedChanges(changes)
             }
         }
     }
 
-    private func handleExtractedChanges(_ changes: [TrackedChange]) {
+    private func handleNotifiedChanges(_ changes: [SyncNotification.Change]) {
         guard !isPulling else { return }
         guard !changes.isEmpty else { return }
 
@@ -117,41 +108,6 @@ final class SyncEngine {
 
         try? context.save()
         schedulePush()
-    }
-
-    private struct TrackedChange: Sendable {
-        let entityType: SyncMetadata.EntityType
-        let entityId: UUID
-        let changeType: SyncMetadata.ChangeType
-    }
-
-    nonisolated private static func extractEntityIds(
-        from objects: Set<NSManagedObject>?,
-        changeType: SyncMetadata.ChangeType
-    ) -> [TrackedChange] {
-        guard let managedObjects = objects else {
-            return []
-        }
-
-        return managedObjects.compactMap { (object: NSManagedObject) -> TrackedChange? in
-            let entityName = object.entity.name ?? ""
-
-            let entityType: SyncMetadata.EntityType
-            switch entityName {
-            case "Account": entityType = .account
-            case "Transaction": entityType = .transaction
-            case "Category": entityType = .category
-            default: return nil
-            }
-
-            guard let id = object.value(forKey: "id") as? UUID else { return nil }
-
-            return TrackedChange(
-                entityType: entityType,
-                entityId: id,
-                changeType: changeType
-            )
-        }
     }
 
     // MARK: - Push (Local → Remote)

--- a/Sources/Services/Sync/SyncMetadata.swift
+++ b/Sources/Services/Sync/SyncMetadata.swift
@@ -1,0 +1,61 @@
+import Foundation
+import SwiftData
+
+// MARK: - Sync Change Tracking (Outbox Pattern)
+
+/// Tracks local changes that need to be pushed to Supabase.
+/// Each record represents a pending insert, update, or delete
+/// that has not yet been confirmed by the remote server.
+@Model
+final class SyncMetadata {
+
+    // MARK: - Properties
+
+    var id: UUID = UUID()
+    var entityType: String = ""
+    var entityId: String = ""
+    var changeType: String = ChangeType.insert.rawValue
+    var timestamp: Date = Date.now
+    var isSynced: Bool = false
+    var retryCount: Int = 0
+
+    // MARK: - Types
+
+    enum ChangeType: String, Codable {
+        case insert
+        case update
+        case delete
+    }
+
+    enum EntityType: String, Codable {
+        case account
+        case transaction
+        case category
+    }
+
+    // MARK: - Computed
+
+    var changeTypeEnum: ChangeType {
+        ChangeType(rawValue: changeType) ?? .insert
+    }
+
+    var entityTypeEnum: EntityType {
+        EntityType(rawValue: entityType) ?? .account
+    }
+
+    // MARK: - Init
+
+    init(
+        entityType: EntityType,
+        entityId: UUID,
+        changeType: ChangeType
+    ) {
+        self.id = UUID()
+        self.entityType = entityType.rawValue
+        self.entityId = entityId.uuidString
+        self.changeType = changeType.rawValue
+        self.timestamp = Date.now
+        self.isSynced = false
+        self.retryCount = 0
+    }
+}

--- a/Sources/Services/Sync/SyncMetadata.swift
+++ b/Sources/Services/Sync/SyncMetadata.swift
@@ -31,6 +31,16 @@ final class SyncMetadata {
         case account
         case transaction
         case category
+
+        /// Push ordering to satisfy foreign key dependencies.
+        /// Accounts and categories must be pushed before transactions.
+        var pushOrder: Int {
+            switch self {
+            case .account: 0
+            case .category: 1
+            case .transaction: 2
+            }
+        }
     }
 
     // MARK: - Computed

--- a/Sources/Services/Sync/SyncNotification.swift
+++ b/Sources/Services/Sync/SyncNotification.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+// MARK: - Sync Change Notification
+
+/// Lightweight notification system for SwiftData saves.
+///
+/// SwiftData's `ModelContext.save()` does NOT post
+/// `NSManagedObjectContextDidSave` (that's Core Data only).
+/// ViewModels post `.didSaveLocalData` after each save so
+/// SyncEngine can queue the change for push.
+enum SyncNotification {
+
+    /// Posted by ViewModels after a successful `modelContext.save()`.
+    static let didSaveLocalData = Notification.Name("SyncDidSaveLocalData")
+
+    // MARK: - UserInfo Keys
+
+    static let changesKey = "syncChanges"
+
+    // MARK: - Change Descriptor
+
+    /// Describes a single entity change to be synced.
+    struct Change: Sendable {
+        let entityType: SyncMetadata.EntityType
+        let entityId: UUID
+        let changeType: SyncMetadata.ChangeType
+    }
+
+    // MARK: - Post Helpers
+
+    /// Post a single entity change.
+    static func post(
+        entityType: SyncMetadata.EntityType,
+        entityId: UUID,
+        changeType: SyncMetadata.ChangeType
+    ) {
+        let change = Change(
+            entityType: entityType,
+            entityId: entityId,
+            changeType: changeType
+        )
+        NotificationCenter.default.post(
+            name: didSaveLocalData,
+            object: nil,
+            userInfo: [changesKey: [change]]
+        )
+    }
+
+    /// Post multiple entity changes at once (e.g., transfer pairs).
+    static func post(changes: [Change]) {
+        guard !changes.isEmpty else { return }
+        NotificationCenter.default.post(
+            name: didSaveLocalData,
+            object: nil,
+            userInfo: [changesKey: changes]
+        )
+    }
+}

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -4,7 +4,6 @@ enum AppConstants {
     static let appName = "FinanceApp"
     static let defaultCurrencyCode = "USD"
     static let recentTransactionsLimit = 10
-    static let categorySeededKey = "hasSeededDefaultCategories"
     static let migrationCompletedKey = "supabaseMigrationCompleted"
     static let lastSyncTimestampKey = "lastSyncTimestamp"
 

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -2,8 +2,14 @@ import Foundation
 
 enum AppConstants {
     static let appName = "FinanceApp"
-    static let cloudKitContainerIdentifier = "iCloud.com.eduardopenedos.FinanceApp"
     static let defaultCurrencyCode = "USD"
     static let recentTransactionsLimit = 10
     static let categorySeededKey = "hasSeededDefaultCategories"
+    static let migrationCompletedKey = "supabaseMigrationCompleted"
+    static let lastSyncTimestampKey = "lastSyncTimestamp"
+
+    // MARK: - Supabase
+
+    static let supabaseURL = URL(string: "https://teeloaxiplwfvonsnudw.supabase.co")!
+    static let supabaseAnonKey = "sb_publishable_vSfgpXsaNd4vpolW8NNCDA_ck9Z-PLx"
 }

--- a/Sources/Utilities/SignOutAction.swift
+++ b/Sources/Utilities/SignOutAction.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct SignOutActionKey: EnvironmentKey {
+    static let defaultValue: (@Sendable () async -> Void)? = nil
+}
+
+extension EnvironmentValues {
+    var signOutAction: (@Sendable () async -> Void)? {
+        get { self[SignOutActionKey.self] }
+        set { self[SignOutActionKey.self] = newValue }
+    }
+}

--- a/Sources/ViewModels/AccountViewModel.swift
+++ b/Sources/ViewModels/AccountViewModel.swift
@@ -24,6 +24,7 @@ final class AccountViewModel {
         )
         modelContext.insert(account)
         try modelContext.save()
+        SyncNotification.post(entityType: .account, entityId: account.id, changeType: .insert)
     }
 
     func updateAccount(
@@ -38,11 +39,14 @@ final class AccountViewModel {
         account.currency = currency.rawValue
         account.icon = icon
         try modelContext.save()
+        SyncNotification.post(entityType: .account, entityId: account.id, changeType: .update)
     }
 
     func deleteAccount(_ account: Account) throws {
+        let accountId = account.id
         modelContext.delete(account)
         try modelContext.save()
+        SyncNotification.post(entityType: .account, entityId: accountId, changeType: .delete)
     }
 
     func formattedBalance(for account: Account) -> String {

--- a/Sources/ViewModels/TransactionViewModel.swift
+++ b/Sources/ViewModels/TransactionViewModel.swift
@@ -28,6 +28,7 @@ final class TransactionViewModel {
         )
         modelContext.insert(transaction)
         try modelContext.save()
+        SyncNotification.post(entityType: .transaction, entityId: transaction.id, changeType: .insert)
     }
 
     func updateTransaction(
@@ -46,14 +47,17 @@ final class TransactionViewModel {
         transaction.account = account
         transaction.category = category
         try modelContext.save()
+        SyncNotification.post(entityType: .transaction, entityId: transaction.id, changeType: .update)
     }
 
     func deleteTransaction(_ transaction: Transaction) throws {
         if let transferId = transaction.transferId {
             try deleteTransferPair(transferId: transferId)
         } else {
+            let transactionId = transaction.id
             modelContext.delete(transaction)
             try modelContext.save()
+            SyncNotification.post(entityType: .transaction, entityId: transactionId, changeType: .delete)
         }
     }
 
@@ -62,9 +66,14 @@ final class TransactionViewModel {
             predicate: #Predicate<Transaction> { $0.transferId == transferId }
         )
         let paired = try modelContext.fetch(descriptor)
+        let pairedIds = paired.map(\.id)
         for transaction in paired {
             modelContext.delete(transaction)
         }
         try modelContext.save()
+        let changes = pairedIds.map { id in
+            SyncNotification.Change(entityType: .transaction, entityId: id, changeType: .delete)
+        }
+        SyncNotification.post(changes: changes)
     }
 }

--- a/Sources/ViewModels/TransferViewModel.swift
+++ b/Sources/ViewModels/TransferViewModel.swift
@@ -48,6 +48,11 @@ final class TransferViewModel {
         modelContext.insert(debit)
         modelContext.insert(credit)
         try modelContext.save()
+
+        SyncNotification.post(changes: [
+            .init(entityType: .transaction, entityId: debit.id, changeType: .insert),
+            .init(entityType: .transaction, entityId: credit.id, changeType: .insert),
+        ])
     }
 
     private func findOrCreateTransferCategory(type: TransactionType) throws -> Category {

--- a/Sources/ViewModels/TransferViewModel.swift
+++ b/Sources/ViewModels/TransferViewModel.swift
@@ -18,8 +18,13 @@ final class TransferViewModel {
     ) throws {
         let transferId = UUID().uuidString
 
-        let transferCategory = try findOrCreateTransferCategory(type: .expense)
-        let transferIncomeCategory = try findOrCreateTransferCategory(type: .income)
+        var newCategoryChanges: [SyncNotification.Change] = []
+        let transferCategory = try findOrCreateTransferCategory(
+            type: .expense, newChanges: &newCategoryChanges
+        )
+        let transferIncomeCategory = try findOrCreateTransferCategory(
+            type: .income, newChanges: &newCategoryChanges
+        )
 
         let defaultNotes = notes.isEmpty
             ? "Transfer from \(sourceAccount.name) to \(destinationAccount.name)"
@@ -49,13 +54,16 @@ final class TransferViewModel {
         modelContext.insert(credit)
         try modelContext.save()
 
-        SyncNotification.post(changes: [
+        SyncNotification.post(changes: newCategoryChanges + [
             .init(entityType: .transaction, entityId: debit.id, changeType: .insert),
             .init(entityType: .transaction, entityId: credit.id, changeType: .insert),
         ])
     }
 
-    private func findOrCreateTransferCategory(type: TransactionType) throws -> Category {
+    private func findOrCreateTransferCategory(
+        type: TransactionType,
+        newChanges: inout [SyncNotification.Change]
+    ) throws -> Category {
         let typeRaw = type.rawValue
         let descriptor = FetchDescriptor<Category>(
             predicate: #Predicate<Category> {
@@ -74,6 +82,7 @@ final class TransferViewModel {
             isDefault: true
         )
         modelContext.insert(category)
+        newChanges.append(.init(entityType: .category, entityId: category.id, changeType: .insert))
         return category
     }
 }

--- a/Sources/Views/Auth/SignInView.swift
+++ b/Sources/Views/Auth/SignInView.swift
@@ -59,7 +59,7 @@ struct SignInView: View {
                     description: "Your data on all your Apple devices"
                 )
             }
-            .padding(.horizontal, 24)
+            .padding(.horizontal, 16)
 
             Spacer()
 
@@ -102,7 +102,12 @@ struct SignInView: View {
             Spacer()
                 .frame(height: 40)
         }
+        #if os(iOS)
+        .padding(.horizontal, 12)
+        .padding(.vertical)
+        #else
         .padding()
+        #endif
         #if os(macOS)
         .frame(minWidth: 500, minHeight: 600)
         #endif
@@ -123,6 +128,7 @@ struct SignInView: View {
                 Text(description)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/Sources/Views/Auth/SignInView.swift
+++ b/Sources/Views/Auth/SignInView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import AuthenticationServices
+
+// MARK: - Sign In View
+
+/// Full-screen sign-in view shown when the user is not authenticated.
+/// Uses Sign in with Apple for a native, privacy-friendly auth flow.
+struct SignInView: View {
+
+    // MARK: - Properties
+
+    let authManager: AuthManager
+
+    @State private var isSigningIn = false
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+
+            // App icon and title
+            VStack(spacing: 16) {
+                Image(systemName: "banknote")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.tint)
+
+                Text(AppConstants.appName)
+                    .font(.largeTitle.bold())
+
+                Text("Track your finances across all your devices")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Spacer()
+
+            // Features list
+            VStack(alignment: .leading, spacing: 12) {
+                featureRow(
+                    icon: "building.columns",
+                    title: "Multiple Accounts",
+                    description: "Checking, savings, credit cards, and more"
+                )
+                featureRow(
+                    icon: "arrow.left.arrow.right",
+                    title: "Transfers",
+                    description: "Move money between accounts"
+                )
+                featureRow(
+                    icon: "chart.pie",
+                    title: "Analytics",
+                    description: "Spending charts and money flow diagrams"
+                )
+                featureRow(
+                    icon: "icloud",
+                    title: "Sync Everywhere",
+                    description: "Your data on all your Apple devices"
+                )
+            }
+            .padding(.horizontal, 24)
+
+            Spacer()
+
+            // Sign in button
+            VStack(spacing: 12) {
+                SignInWithAppleButton(
+                    .signIn,
+                    onRequest: { request in
+                        let appleRequest = authManager.createAppleIDRequest()
+                        request.requestedScopes = appleRequest.requestedScopes
+                        request.nonce = appleRequest.nonce
+                    },
+                    onCompletion: { result in
+                        isSigningIn = true
+                        Task {
+                            await authManager.handleAppleSignIn(result: result)
+                            isSigningIn = false
+                        }
+                    }
+                )
+                .signInWithAppleButtonStyle(.black)
+                .frame(height: 50)
+                .frame(maxWidth: 320)
+                .disabled(isSigningIn)
+
+                if isSigningIn {
+                    ProgressView()
+                        .padding(.top, 8)
+                }
+
+                if let error = authManager.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+            }
+
+            Spacer()
+                .frame(height: 40)
+        }
+        .padding()
+        #if os(macOS)
+        .frame(minWidth: 500, minHeight: 600)
+        #endif
+    }
+
+    // MARK: - Components
+
+    private func featureRow(icon: String, title: String, description: String) -> some View {
+        HStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(.tint)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/Sources/Views/Categories/CategoryFormView.swift
+++ b/Sources/Views/Categories/CategoryFormView.swift
@@ -177,6 +177,8 @@ struct CategoryFormView: View {
                 category.icon = icon
                 category.colorHex = colorHex
                 category.transactionType = transactionType.rawValue
+                try modelContext.save()
+                SyncNotification.post(entityType: .category, entityId: category.id, changeType: .update)
             } else {
                 let newCategory = Category(
                     name: trimmedName,
@@ -185,8 +187,9 @@ struct CategoryFormView: View {
                     transactionType: transactionType
                 )
                 modelContext.insert(newCategory)
+                try modelContext.save()
+                SyncNotification.post(entityType: .category, entityId: newCategory.id, changeType: .insert)
             }
-            try modelContext.save()
             dismiss()
         } catch {
             errorMessage = "Failed to save category: \(error.localizedDescription)"

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -3,12 +3,9 @@ import SwiftData
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
-    @Environment(\.signOutAction) private var signOutAction
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     #endif
-
-    @State private var showSignOutConfirmation = false
 
     var body: some View {
         Group {
@@ -21,11 +18,6 @@ struct ContentView: View {
             #else
             sidebarLayout
             #endif
-        }
-        .confirmationDialog("Are you sure you want to sign out?", isPresented: $showSignOutConfirmation, titleVisibility: .visible) {
-            Button("Sign Out", role: .destructive) {
-                Task { await signOutAction?() }
-            }
         }
     }
 
@@ -49,19 +41,6 @@ struct ContentView: View {
         TabView {
             NavigationStack {
                 DashboardView()
-                    .toolbar {
-                        ToolbarItem(placement: .topBarTrailing) {
-                            Menu {
-                                Button(role: .destructive) {
-                                    showSignOutConfirmation = true
-                                } label: {
-                                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
-                                }
-                            } label: {
-                                Image(systemName: "person.circle")
-                            }
-                        }
-                    }
             }
             .tabItem { Label("Dashboard", systemImage: "chart.pie") }
 
@@ -79,6 +58,11 @@ struct ContentView: View {
                 CategoryListView()
             }
             .tabItem { Label("Categories", systemImage: "tag") }
+
+            NavigationStack {
+                SettingsTabView()
+            }
+            .tabItem { Label("Settings", systemImage: "gearshape") }
         }
     }
     #endif

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -3,20 +3,30 @@ import SwiftData
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.signOutAction) private var signOutAction
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     #endif
 
+    @State private var showSignOutConfirmation = false
+
     var body: some View {
-        #if os(iOS)
-        if horizontalSizeClass == .regular {
+        Group {
+            #if os(iOS)
+            if horizontalSizeClass == .regular {
+                sidebarLayout
+            } else {
+                compactLayout
+            }
+            #else
             sidebarLayout
-        } else {
-            compactLayout
+            #endif
         }
-        #else
-        sidebarLayout
-        #endif
+        .confirmationDialog("Are you sure you want to sign out?", isPresented: $showSignOutConfirmation, titleVisibility: .visible) {
+            Button("Sign Out", role: .destructive) {
+                Task { await signOutAction?() }
+            }
+        }
     }
 
     // MARK: - Sidebar Layout (macOS + iPad)
@@ -39,6 +49,19 @@ struct ContentView: View {
         TabView {
             NavigationStack {
                 DashboardView()
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Menu {
+                                Button(role: .destructive) {
+                                    showSignOutConfirmation = true
+                                } label: {
+                                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                                }
+                            } label: {
+                                Image(systemName: "person.circle")
+                            }
+                        }
+                    }
             }
             .tabItem { Label("Dashboard", systemImage: "chart.pie") }
 
@@ -64,6 +87,10 @@ struct ContentView: View {
 // MARK: - Sidebar (shared between macOS and iPadOS)
 
 struct SidebarView: View {
+    @Environment(\.signOutAction) private var signOutAction
+
+    @State private var showSignOutConfirmation = false
+
     var body: some View {
         List {
             NavigationLink {
@@ -103,8 +130,21 @@ struct SidebarView: View {
                     Label("Spending", systemImage: "chart.pie")
                 }
             }
+
+            Section {
+                Button(role: .destructive) {
+                    showSignOutConfirmation = true
+                } label: {
+                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            }
         }
         .navigationTitle("Finance")
+        .confirmationDialog("Are you sure you want to sign out?", isPresented: $showSignOutConfirmation, titleVisibility: .visible) {
+            Button("Sign Out", role: .destructive) {
+                Task { await signOutAction?() }
+            }
+        }
         #if os(macOS)
         .listStyle(.sidebar)
         #endif

--- a/Sources/Views/Dashboard/DashboardView.swift
+++ b/Sources/Views/Dashboard/DashboardView.swift
@@ -52,7 +52,7 @@ struct DashboardView: View {
         .background(backgroundFill)
         .navigationTitle("Dashboard")
         #if os(iOS)
-        .navigationBarTitleDisplayMode(isCompact ? .inline : .large)
+        .navigationBarTitleDisplayMode(.large)
         #endif
         .sheet(isPresented: $showingAddTransaction) {
             TransactionFormView(transaction: nil)
@@ -65,27 +65,23 @@ struct DashboardView: View {
     // MARK: - Compact iPhone Layout
 
     private var compactBody: some View {
-        VStack(spacing: 0) {
-            // Hero balance area — full width, no padding
-            compactBalanceHeader
-
-            VStack(spacing: 12) {
-                monthlyRow
-                quickActions
-                chartsRow
-                accountsCard
-                recentCard
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
-            .padding(.bottom, 32)
+        VStack(spacing: 12) {
+            compactBalanceCard
+            monthlyRow
+            quickActions
+            chartsRow
+            accountsCard
+            recentCard
         }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 32)
     }
 
-    private var compactBalanceHeader: some View {
-        VStack(spacing: 2) {
+    private var compactBalanceCard: some View {
+        VStack(spacing: 4) {
             Text("Total Balance")
-                .font(.caption.weight(.medium))
+                .font(.footnote.weight(.medium))
                 .foregroundStyle(.secondary)
 
             Text(CurrencyFormatter.displayString(
@@ -97,17 +93,8 @@ struct DashboardView: View {
             .contentTransition(.numericText())
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 16)
-        .background(
-            LinearGradient(
-                colors: [
-                    Color.accentColor.opacity(0.12),
-                    Color.accentColor.opacity(0.03)
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
+        .padding(.vertical, 20)
+        .background(cardShape)
     }
 
     // MARK: - Regular / Wide Layout (iPad & macOS)
@@ -221,7 +208,7 @@ struct DashboardView: View {
                     Text("Transaction")
                 }
                 .font(.subheadline.weight(.semibold))
-                .frame(maxWidth: .infinity, minHeight: 44)
+                .frame(maxWidth: .infinity, minHeight: 40)
                 .foregroundStyle(.white)
                 .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 11))
             }
@@ -235,7 +222,7 @@ struct DashboardView: View {
                     Text("Transfer")
                 }
                 .font(.subheadline.weight(.semibold))
-                .frame(maxWidth: .infinity, minHeight: 44)
+                .frame(maxWidth: .infinity, minHeight: 40)
                 .foregroundStyle(Color.accentColor)
                 .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 11))
             }
@@ -255,7 +242,7 @@ struct DashboardView: View {
                     Text("Money Flow")
                 }
                 .font(.subheadline.weight(.medium))
-                .frame(maxWidth: .infinity, minHeight: 38)
+                .frame(maxWidth: .infinity, minHeight: 34)
                 .foregroundStyle(.primary)
                 .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))
             }
@@ -269,7 +256,7 @@ struct DashboardView: View {
                     Text("Spending")
                 }
                 .font(.subheadline.weight(.medium))
-                .frame(maxWidth: .infinity, minHeight: 38)
+                .frame(maxWidth: .infinity, minHeight: 34)
                 .foregroundStyle(.primary)
                 .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))
             }

--- a/Sources/Views/Settings/SettingsTabView.swift
+++ b/Sources/Views/Settings/SettingsTabView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+// MARK: - Settings Tab View (iPhone)
+
+struct SettingsTabView: View {
+    @Environment(\.signOutAction) private var signOutAction
+
+    @State private var showSignOutConfirmation = false
+
+    var body: some View {
+        List {
+            Section {
+                Button(role: .destructive) {
+                    showSignOutConfirmation = true
+                } label: {
+                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            }
+        }
+        .navigationTitle("Settings")
+        .confirmationDialog(
+            "Are you sure you want to sign out?",
+            isPresented: $showSignOutConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Sign Out", role: .destructive) {
+                Task { await signOutAction?() }
+            }
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -7,6 +7,11 @@ options:
   xcodeVersion: "16.0"
   generateEmptyDirectories: true
 
+packages:
+  Supabase:
+    url: https://github.com/supabase-community/supabase-swift
+    from: "2.0.0"
+
 settings:
   base:
     SWIFT_VERSION: "6.0"
@@ -42,6 +47,8 @@ targets:
     platform: iOS
     templates:
       - AppBase
+    dependencies:
+      - package: Supabase
     settings:
       base:
         TARGETED_DEVICE_FAMILY: "1,2"
@@ -51,6 +58,8 @@ targets:
     platform: macOS
     templates:
       - AppBase
+    dependencies:
+      - package: Supabase
 
   FinanceAppTests-iOS:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

- **Add dedicated Settings tab on iPhone** with a clear Sign Out button, replacing the hidden toolbar menu (person.circle icon) that was only on the Dashboard tab
- **Fix text truncation on SignInView** by adding `.fixedSize(horizontal: false, vertical: true)` to feature descriptions and reducing excessive horizontal padding

## Changes

| File | Change |
|------|--------|
| `Sources/Views/Settings/SettingsTabView.swift` | New Settings tab view with sign-out button and confirmation dialog |
| `Sources/Views/ContentView.swift` | Replace toolbar menu with 5th Settings tab in iPhone compact layout |
| `Sources/Views/Auth/SignInView.swift` | Fix text wrapping and reduce padding for better iOS sizing |
| `FinanceApp.xcodeproj/project.pbxproj` | Add new file to both iOS and macOS build targets |

## Test plan

- [ ] Verify 5 tabs appear on iPhone (Dashboard, Accounts, Transactions, Categories, Settings)
- [ ] Verify tapping Sign Out in Settings tab shows confirmation dialog
- [ ] Verify sign-out completes successfully after confirmation
- [ ] Verify SignInView feature descriptions no longer truncate on iPhone
- [ ] Verify iPad sidebar layout is unchanged (sign-out still in sidebar bottom section)
- [ ] Verify macOS layout is unchanged

https://claude.ai/code/session_016aKSjG46iGsCrLJQVsaWmq