### PR TITLE
Fix iPhone SignInView layout to fill full screen

### DIFF
--- a/Sources/Views/Auth/SignInView.swift
+++ b/Sources/Views/Auth/SignInView.swift
@@ -16,101 +16,106 @@ struct SignInView: View {
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: 32) {
-            Spacer()
+        ZStack {
+            #if os(iOS)
+            Color(uiColor: .systemBackground)
+                .ignoresSafeArea()
+            #else
+            Color(nsColor: .windowBackgroundColor)
+                .ignoresSafeArea()
+            #endif
 
-            // App icon and title
-            VStack(spacing: 16) {
-                Image(systemName: "banknote")
-                    .font(.system(size: 64))
-                    .foregroundStyle(.tint)
+            VStack(spacing: 32) {
+                Spacer()
 
-                Text(AppConstants.appName)
-                    .font(.largeTitle.bold())
+                // App icon and title
+                VStack(spacing: 16) {
+                    Image(systemName: "banknote")
+                        .font(.system(size: 64))
+                        .foregroundStyle(.tint)
 
-                Text("Track your finances across all your devices")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
+                    Text(AppConstants.appName)
+                        .font(.largeTitle.bold())
 
-            Spacer()
-
-            // Features list
-            VStack(alignment: .leading, spacing: 12) {
-                featureRow(
-                    icon: "building.columns",
-                    title: "Multiple Accounts",
-                    description: "Checking, savings, credit cards, and more"
-                )
-                featureRow(
-                    icon: "arrow.left.arrow.right",
-                    title: "Transfers",
-                    description: "Move money between accounts"
-                )
-                featureRow(
-                    icon: "chart.pie",
-                    title: "Analytics",
-                    description: "Spending charts and money flow diagrams"
-                )
-                featureRow(
-                    icon: "icloud",
-                    title: "Sync Everywhere",
-                    description: "Your data on all your Apple devices"
-                )
-            }
-            .padding(.horizontal, 16)
-
-            Spacer()
-
-            // Sign in button
-            VStack(spacing: 12) {
-                SignInWithAppleButton(
-                    .signIn,
-                    onRequest: { request in
-                        let appleRequest = authManager.createAppleIDRequest()
-                        request.requestedScopes = appleRequest.requestedScopes
-                        request.nonce = appleRequest.nonce
-                    },
-                    onCompletion: { result in
-                        isSigningIn = true
-                        Task {
-                            await authManager.handleAppleSignIn(result: result)
-                            isSigningIn = false
-                        }
-                    }
-                )
-                .signInWithAppleButtonStyle(.black)
-                .frame(height: 50)
-                .frame(maxWidth: 320)
-                .disabled(isSigningIn)
-
-                if isSigningIn {
-                    ProgressView()
-                        .padding(.top, 8)
-                }
-
-                if let error = authManager.errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                    Text("Track your finances across all your devices")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
-                        .padding(.horizontal)
                 }
-            }
 
-            Spacer()
-                .frame(height: 40)
+                // Features list
+                VStack(alignment: .leading, spacing: 12) {
+                    featureRow(
+                        icon: "building.columns",
+                        title: "Multiple Accounts",
+                        description: "Checking, savings, credit cards, and more"
+                    )
+                    featureRow(
+                        icon: "arrow.left.arrow.right",
+                        title: "Transfers",
+                        description: "Move money between accounts"
+                    )
+                    featureRow(
+                        icon: "chart.pie",
+                        title: "Analytics",
+                        description: "Spending charts and money flow diagrams"
+                    )
+                    featureRow(
+                        icon: "icloud",
+                        title: "Sync Everywhere",
+                        description: "Your data on all your Apple devices"
+                    )
+                }
+                .padding(.horizontal, 16)
+
+                // Sign in button
+                VStack(spacing: 12) {
+                    SignInWithAppleButton(
+                        .signIn,
+                        onRequest: { request in
+                            let appleRequest = authManager.createAppleIDRequest()
+                            request.requestedScopes = appleRequest.requestedScopes
+                            request.nonce = appleRequest.nonce
+                        },
+                        onCompletion: { result in
+                            isSigningIn = true
+                            Task {
+                                await authManager.handleAppleSignIn(result: result)
+                                isSigningIn = false
+                            }
+                        }
+                    )
+                    .signInWithAppleButtonStyle(.black)
+                    .frame(height: 50)
+                    .frame(maxWidth: 320)
+                    .disabled(isSigningIn)
+
+                    if isSigningIn {
+                        ProgressView()
+                            .padding(.top, 8)
+                    }
+
+                    if let error = authManager.errorMessage {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                    }
+                }
+
+                Spacer()
+            }
+            #if os(iOS)
+            .padding(.horizontal, 24)
+            .padding(.vertical)
+            #else
+            .padding()
+            #endif
+            #if os(macOS)
+            .frame(minWidth: 500, minHeight: 600)
+            #endif
         }
-        #if os(iOS)
-        .padding(.horizontal, 12)
-        .padding(.vertical)
-        #else
-        .padding()
-        #endif
-        #if os(macOS)
-        .frame(minWidth: 500, minHeight: 600)
-        #endif
     }
 
     // MARK: - Components


### PR DESCRIPTION
## Changes

- Wrapped view hierarchy in `ZStack` with explicit background color handling for iOS and macOS
- Added platform-specific background color using `systemBackground` for iOS and `windowBackgroundColor` for macOS
- Applied `.ignoresSafeArea()` to background to ensure full screen coverage
- Adjusted padding strategy: increased horizontal padding to 24 for iOS while maintaining platform-specific vertical padding
- Reorganized layout to properly distribute spacers and content

## Result

SignInView now properly fills the entire iPhone screen with appropriate background color handling across platforms.